### PR TITLE
FIX: Typing error with ClsStore interface

### DIFF
--- a/src/lib/cls.interfaces.ts
+++ b/src/lib/cls.interfaces.ts
@@ -160,6 +160,4 @@ export class ClsInterceptorOptions {
     readonly namespaceName?: string;
 }
 
-export interface ClsStore {
-    [key: symbol]: any;
-}
+export type ClsStore = Record<symbol, any>;


### PR DESCRIPTION
This PRis going to closes #20. 

Seems like Records works much better for mixings. Can't explain the deep reason but it fixes the issue with lower version of Typescript v4.3.5