### PR TITLE
fix: add `AbortController` to the terminal types list

### DIFF
--- a/src/lib/cls.service.ts
+++ b/src/lib/cls.service.ts
@@ -29,7 +29,7 @@ export class ClsService<S extends ClsStore = ClsStore> {
         const store = this.als.getStore();
         if (!store) {
             throw new Error(
-                `Cannot se the key "${String(
+                `Cannot set the key "${String(
                     key,
                 )}". No CLS context available, please make sure that a ClsMiddleware/Guard/Interceptor has set up the context, or wrap any calls that depend on CLS with "ClsService#run"`,
             );

--- a/src/types/recursive-key-of.type.ts
+++ b/src/types/recursive-key-of.type.ts
@@ -55,12 +55,13 @@ export type RecursiveKeyOf<
 export type DeepPropertyType<
     T,
     P extends RecursiveKeyOf<T>,
+    TT = Exclude<T, undefined>,
 > = P extends `${infer Prefix}.${infer Rest}`
-    ? Prefix extends keyof T
-        ? Rest extends RecursiveKeyOf<T[Prefix]>
-            ? DeepPropertyType<T[Prefix], Rest>
+    ? Prefix extends keyof TT
+        ? Rest extends RecursiveKeyOf<TT[Prefix]>
+            ? DeepPropertyType<TT[Prefix], Rest>
             : never
         : never
-    : P extends keyof T
-    ? T[P]
+    : P extends keyof TT
+    ? TT[P]
     : never;

--- a/src/types/recursive-key-of.type.ts
+++ b/src/types/recursive-key-of.type.ts
@@ -16,6 +16,16 @@ type TerminalType =
     | ((...args: any) => any);
 
 /**
+ * Evaluates to `true` if `T` is `any`. `false` otherwise.
+ * (c) https://stackoverflow.com/a/68633327/5290447
+ */
+type IsAny<T> = unknown extends T
+    ? [keyof T] extends [never]
+        ? false
+        : true
+    : false;
+
+/**
  * Deep nested keys of an interface with dot syntax
  *
  * @example
@@ -25,6 +35,8 @@ export type RecursiveKeyOf<
     T,
     Prefix extends string = never,
 > = T extends TerminalType
+    ? never
+    : IsAny<T> extends true
     ? never
     : {
           [K in keyof T & string]: [Prefix] extends [never]

--- a/src/types/recursive-key-of.type.ts
+++ b/src/types/recursive-key-of.type.ts
@@ -12,6 +12,7 @@ type TerminalType =
     | Set<any>
     | Date
     | RegExp
+    | AbortController
     | BrandedTerminal
     | ((...args: any) => any);
 


### PR DESCRIPTION
I've made this change on `@nestjs/config`: https://github.com/nestjs/config/pull/907 I found that it closes #46 as well