### PR TITLE
docs: update docs and tests for gql

### DIFF
--- a/.github/workflows/run-tests.workflow.yml
+++ b/.github/workflows/run-tests.workflow.yml
@@ -14,11 +14,14 @@ concurrency:
 jobs:
   run_tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: ${{ matrix.node }}.x
           cache: npm
       - run: npm ci --audit=false
       - run: npm run lint

--- a/test/gql/gql-apollo.spec.ts
+++ b/test/gql/gql-apollo.spec.ts
@@ -7,10 +7,13 @@ import { GraphQLModule } from '@nestjs/graphql';
 import { ApolloDriver } from '@nestjs/apollo';
 
 let app: INestApplication;
-describe('GQL Apollo App - Manually bound Middleware in Bootstrap', () => {
+describe('GQL Apollo App - Auto bound Middleware', () => {
     @Module({
         imports: [
-            ClsModule.forRoot({ global: true }),
+            ClsModule.forRoot({
+                global: true,
+                middleware: { mount: true, generateId: true },
+            }),
             ItemModule,
             GraphQLModule.forRoot({
                 driver: ApolloDriver,
@@ -25,9 +28,6 @@ describe('GQL Apollo App - Manually bound Middleware in Bootstrap', () => {
             imports: [AppModule],
         }).compile();
         app = moduleFixture.createNestApplication();
-        app.use(
-            new ClsMiddleware({ useEnterWith: true, generateId: true }).use,
-        );
         await app.init();
     });
 

--- a/test/gql/gql-mercurius.spec.ts
+++ b/test/gql/gql-mercurius.spec.ts
@@ -11,10 +11,13 @@ import { GraphQLModule } from '@nestjs/graphql';
 import { MercuriusDriver } from '@nestjs/mercurius';
 
 let app: NestFastifyApplication;
-describe('GQL Mercurius App - Manually bound Middleware in Bootstrap', () => {
+describe('GQL Mercurius App - Auto bound Middleware', () => {
     @Module({
         imports: [
-            ClsModule.forRoot({ global: true }),
+            ClsModule.forRoot({
+                global: true,
+                middleware: { mount: true, generateId: true },
+            }),
             ItemModule,
             GraphQLModule.forRoot({
                 driver: MercuriusDriver,
@@ -29,9 +32,6 @@ describe('GQL Mercurius App - Manually bound Middleware in Bootstrap', () => {
             AppModule,
             new FastifyAdapter(),
             { logger: false },
-        );
-        app.use(
-            new ClsMiddleware({ generateId: true, useEnterWith: true }).use,
         );
         await app.init();
         await app.getHttpAdapter().getInstance().ready();


### PR DESCRIPTION
Context setup for GQL no longer requires `useEnterWith`