### PR TITLE
Add res to middleware setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,13 +307,13 @@ class MyService {
 
 The CLS middleware/guard/interceptor provide some default functionality, but sometimes you might want to store more things about the request in the context. This can be of course done in a custom enhancer bound after, but for this scenario the options expose the `setup` function, which will be executed in the enhancer right after the CLS context is set up.
 
-The function receives the `ClsService` instance and the `Request` (or `ExecutionContext`) object, and can be asynchronous.
+The function receives the `ClsService` instance, the `Request` and `Response` objects (or the `ExecutionContext` object) , and can be asynchronous.
 
 ```ts
 ClsModule.forRoot({
     middleware: {
         mount: true,
-        setup: (cls, req: Request) => {
+        setup: (cls, req: Request, res: Response) => {
             // put some additional default info in the CLS
             cls.set('TENANT_ID', req.params('tenant_id'));
             cls.set('AUTH', { authenticated: false });

--- a/src/lib/cls-initializers/cls.middleware.ts
+++ b/src/lib/cls-initializers/cls.middleware.ts
@@ -32,7 +32,7 @@ export class ClsMiddleware implements NestMiddleware {
                 if (this.options.saveReq) cls.set<any>(CLS_REQ, req);
                 if (this.options.saveRes) cls.set<any>(CLS_RES, res);
                 if (this.options.setup) {
-                    await this.options.setup(cls, req);
+                    await this.options.setup(cls, req, res);
                 }
                 if (this.options.resolveProxyProviders)
                     await cls.resolveProxyProviders();

--- a/src/lib/cls.options.ts
+++ b/src/lib/cls.options.ts
@@ -8,7 +8,7 @@ export class ClsModuleOptions {
      * whether to make the module global, so you don't need
      * to import ClsModule.forFeature()` in other modules
      */
-    global? = false;
+    global?= false;
 
     /**
      * An object with additional options for the `ClsMiddleware`
@@ -72,7 +72,7 @@ export class ClsMiddlewareOptions {
      * Function that executes after the CLS context has been initialised.
      * It can be used to put additional variables in the CLS context.
      */
-    setup?: (cls: ClsService, req: any) => void | Promise<void>;
+    setup?: (cls: ClsService, req: any, res: any) => void | Promise<void>;
 
     /**
      * Whether to resolve proxy providers as a part
@@ -80,19 +80,19 @@ export class ClsMiddlewareOptions {
      *
      * Default: `true`
      */
-    resolveProxyProviders? = true;
+    resolveProxyProviders?= true;
 
     /**
      * Whether to store the Request object to the CLS
      * It will be available under the CLS_REQ key
      */
-    saveReq? = true;
+    saveReq?= true;
 
     /**
      * Whether to store the Response object to the CLS
      * It will be available under the CLS_RES key
      */
-    saveRes? = false;
+    saveRes?= false;
 
     /**
      * Set to true to set up the context using a call to
@@ -102,7 +102,7 @@ export class ClsMiddlewareOptions {
      * Most of the time this should not be necessary, but
      * some frameworks are known to lose the context wih `run`.
      */
-    useEnterWith? = false;
+    useEnterWith?= false;
 }
 
 export class ClsGuardOptions {
@@ -137,7 +137,7 @@ export class ClsGuardOptions {
      *
      * Default: `true`
      */
-    resolveProxyProviders? = true;
+    resolveProxyProviders?= true;
 }
 
 export class ClsInterceptorOptions {
@@ -172,7 +172,7 @@ export class ClsInterceptorOptions {
      *
      * Default: `true`
      */
-    resolveProxyProviders? = true;
+    resolveProxyProviders?= true;
 }
 
 export class ClsDecoratorOptions<T extends any[]> {
@@ -206,7 +206,7 @@ export class ClsDecoratorOptions<T extends any[]> {
      *
      * Default: `false`
      */
-    resolveProxyProviders? = false;
+    resolveProxyProviders?= false;
 }
 
 export interface ClsStore {

--- a/src/lib/cls.options.ts
+++ b/src/lib/cls.options.ts
@@ -8,7 +8,7 @@ export class ClsModuleOptions {
      * whether to make the module global, so you don't need
      * to import ClsModule.forFeature()` in other modules
      */
-    global?= false;
+    global? = false;
 
     /**
      * An object with additional options for the `ClsMiddleware`
@@ -72,7 +72,7 @@ export class ClsMiddlewareOptions {
      * Function that executes after the CLS context has been initialised.
      * It can be used to put additional variables in the CLS context.
      */
-    setup?: (cls: ClsService, req: any, res?: any) => void | Promise<void>;
+    setup?: (cls: ClsService, req: any, res: any) => void | Promise<void>;
 
     /**
      * Whether to resolve proxy providers as a part
@@ -80,19 +80,19 @@ export class ClsMiddlewareOptions {
      *
      * Default: `true`
      */
-    resolveProxyProviders?= true;
+    resolveProxyProviders? = true;
 
     /**
      * Whether to store the Request object to the CLS
      * It will be available under the CLS_REQ key
      */
-    saveReq?= true;
+    saveReq? = true;
 
     /**
      * Whether to store the Response object to the CLS
      * It will be available under the CLS_RES key
      */
-    saveRes?= false;
+    saveRes? = false;
 
     /**
      * Set to true to set up the context using a call to
@@ -102,7 +102,7 @@ export class ClsMiddlewareOptions {
      * Most of the time this should not be necessary, but
      * some frameworks are known to lose the context wih `run`.
      */
-    useEnterWith?= false;
+    useEnterWith? = false;
 }
 
 export class ClsGuardOptions {
@@ -137,7 +137,7 @@ export class ClsGuardOptions {
      *
      * Default: `true`
      */
-    resolveProxyProviders?= true;
+    resolveProxyProviders? = true;
 }
 
 export class ClsInterceptorOptions {
@@ -172,7 +172,7 @@ export class ClsInterceptorOptions {
      *
      * Default: `true`
      */
-    resolveProxyProviders?= true;
+    resolveProxyProviders? = true;
 }
 
 export class ClsDecoratorOptions<T extends any[]> {
@@ -206,7 +206,7 @@ export class ClsDecoratorOptions<T extends any[]> {
      *
      * Default: `false`
      */
-    resolveProxyProviders?= false;
+    resolveProxyProviders? = false;
 }
 
 export interface ClsStore {

--- a/src/lib/cls.options.ts
+++ b/src/lib/cls.options.ts
@@ -72,7 +72,7 @@ export class ClsMiddlewareOptions {
      * Function that executes after the CLS context has been initialised.
      * It can be used to put additional variables in the CLS context.
      */
-    setup?: (cls: ClsService, req: any, res: any) => void | Promise<void>;
+    setup?: (cls: ClsService, req: any, res?: any) => void | Promise<void>;
 
     /**
      * Whether to resolve proxy providers as a part


### PR DESCRIPTION
use case is initializing iron-session ([vvo/iron-session](https://github.com/vvo/iron-session)) and adding the session object or just specific session data to continuation-local storage. Iron-session requires the response object to initialize and fails without it (even though it's not really needed until you call session.save() or session.destroy(). see https://github.com/vvo/iron-session/blob/70d2ff14aacb51e83284d51832fdcda539b4dabc/src/core.ts#L107)

An example implementation could look like this:
```typescript
ClsModule.forRoot({
    middleware: {
        mount: true,
        setup: (cls, req: Request, res:Response) => {
          const session = await getIronSession(req, res, {
              cookieName: "myapp_cookiename",
              password: "complex_password_at_least_32_characters_long",
              // secure: true should be used in production (HTTPS) but can't be used in development (HTTP)
              cookieOptions: {
                secure: process.env.NODE_ENV === "production",
              },
            });

		// Put session object in CLS...
            cls.set('SESSION', session);

		// Or, put value pulled off session into CLS
	     cls.set('TENANTS_ID', session.tenantsId);
        },
    },
});
```