### PR TITLE
fix: explicitly enable function proxy providers

### DIFF
--- a/docs/docs/03_features-and-use-cases/06_proxy-providers.md
+++ b/docs/docs/03_features-and-use-cases/06_proxy-providers.md
@@ -153,11 +153,29 @@ class DogsService {
 
 Proxy Factory providers _cannot_ return a _primitive value_. This is because the provider itself is the Proxy and it only delegates access once a property or a method is called on it (or if it itself is called in case the factory returns a function).
 
-### `typeof` Proxies is always `function`
+### `function` Proxies must be explicitly enabled
 
-In order to support injecting proxies of _functions_, the underlying proxy _target_ is an empty function, too. It must be this way in order to be able to implement the "apply" trap.
+In order to support injecting proxies of _functions_, the underlying proxy _target_ must be a function, too, in order to be able to implement the "apply" trap. However, this information cannot be extracted from the factory function itself, so if your factory returns a function, you must explicitly set the `type` property to `function` in the provider definition.
 
-As a result of this, calling `typeof` on an instance of a Proxy will always return `function`, regardless of the value it holds. This is fine for most applications, but must be taken into consideration in some cases - please see [Issue #82](https://github.com/Papooch/nestjs-cls/issues/82) for more info and possible workarounds.
+```ts
+{
+    provide: SOME_FUNCTION,
+    useFactory: () => {
+        return () => {
+            // do something
+        };
+    },
+    // highlight-start
+    type: 'function',
+    // highlight-end
+}
+```
+
+:::note
+
+In versions prior to `v4.0`, calling `typeof` on an instance of a Proxy provider always returned `function`, regardless of the value it holds. This is no longer the case. Please see [Issue #82](https://github.com/Papooch/nestjs-cls/issues/82)
+
+:::
 
 ## Delayed resolution of Proxy Providers
 

--- a/docs/docs/04_api/02_module-options.md
+++ b/docs/docs/04_api/02_module-options.md
@@ -55,6 +55,9 @@ The `ClsModuleProxyFactoryProviderOptions` interface further accepts:
 -   **_`useFactory:`_ `(...args: any[]) => any`**  
     Factory function that accepts an array of providers in the order of the according tokens in the `inject` array. Returns (or resolves with) an object (or a function) that will be used by this Proxy Provider.
 
+-   **_`type?:`_ `'function' | 'object'`**  
+     Whether the Proxy Provider should be a function or an object. Defaults to `'object'`. See [Caveats](../03_features-and-use-cases/06_proxy-providers.md#caveats) for more information.
+
 ## Middleware & Enhancer options
 
 All of the **`Cls{Middleware,Guard,Interceptor}Options`** take the following parameters (either in `ClsModuleOptions` or directly when instantiating them manually):

--- a/packages/core/src/lib/proxy-provider/proxy-provider-manager.ts
+++ b/packages/core/src/lib/proxy-provider/proxy-provider-manager.ts
@@ -15,6 +15,7 @@ import {
     ClsModuleProxyClassProviderOptions,
     ClsModuleProxyFactoryProviderOptions,
     ClsModuleProxyProviderOptions,
+    ClsProxyFactoryReturnType,
     ProxyClassProvider,
     ProxyFactoryProvider,
     ProxyProvider,
@@ -26,7 +27,10 @@ export class ProxyProviderManager {
 
     static createProxyProvider(options: ClsModuleProxyProviderOptions) {
         const providerSymbol = this.getProxyProviderSymbol(options);
-        const proxy = this.createProxy(providerSymbol);
+        const proxy = this.createProxy(
+            providerSymbol,
+            (options as ClsModuleProxyFactoryProviderOptions).type ?? 'object',
+        );
         const proxyProvider: FactoryProvider = {
             provide: this.getProxyProviderToken(options),
             inject: [
@@ -90,9 +94,13 @@ export class ProxyProviderManager {
         );
     }
 
-    private static createProxy(providerKey: symbol | string): any {
+    private static createProxy(
+        providerKey: symbol | string,
+        type: ClsProxyFactoryReturnType = 'object',
+    ): any {
         const getProvider = () => this.clsService.get()?.[providerKey] ?? {};
-        return new Proxy(() => null, {
+        const baseType = type === 'function' ? () => null : {};
+        return new Proxy(baseType, {
             apply(_, thisArg, argArray) {
                 return getProvider().apply(thisArg, argArray);
             },

--- a/packages/core/src/lib/proxy-provider/proxy-provider.interfaces.ts
+++ b/packages/core/src/lib/proxy-provider/proxy-provider.interfaces.ts
@@ -52,7 +52,17 @@ export interface ClsModuleProxyFactoryProviderOptions
      * Returns (or resolves with) an object (or a function) that will be used by this Proxy Provider.
      */
     useFactory: (...args: any[]) => any;
+
+    /**
+     * Explicit type of the value returned by the `useFactory` function. This is required to construct the base value of the Proxy
+     * when the `useFactory` function returns a non-object value
+     *
+     * Default: 'object'
+     */
+    type?: ClsProxyFactoryReturnType;
 }
+
+export type ClsProxyFactoryReturnType = 'object' | 'function';
 
 export type ClsModuleProxyProviderOptions =
     | ClsModuleProxyClassProviderOptions

--- a/packages/core/test/proxy-providers/for-feature.spec.ts
+++ b/packages/core/test/proxy-providers/for-feature.spec.ts
@@ -282,12 +282,14 @@ describe('ClsModule', () => {
                     extraProviders: [SomeClass],
                     inject: [SomeClass],
                     useFactory: (some: SomeClass) => () => some,
+                    type: 'function',
                 }),
             ]);
             await cls.run(async () => {
                 await expect(
                     cls.resolveProxyProviders(),
                 ).resolves.not.toThrow();
+                expect(typeof app.get(TOKEN)).toBe('function');
                 expect(app.get(TOKEN)()).toBeInstanceOf(SomeClass);
             });
         });


### PR DESCRIPTION
BREAKING CHANGE: Proxied object now has `object` type by default. Proxies of `function` types must be explicitly enabled by using `type: 'function'` in the `forFeature` registration.

Closes #82 