### PR TITLE
chore: change default of nested cls option

### DIFF
--- a/docs/docs/04_api/01_service-interface.md
+++ b/docs/docs/04_api/01_service-interface.md
@@ -51,10 +51,17 @@ The `S` type parameter is used as the type of custom `ClsStore`.
 
 The `run` and `enter` methods can take an additional options object with the following settings:
 
--   **_`ifNested?:`_** `'override' | 'inherit' | 'reuse'`  
+-   **_`ifNested?:`_** `'inherit' | 'reuse' | 'override'`  
     Sets the behavior of nested CLS context creation in case the method is invoked in an existing context. It has no effect if no parent context exist.
-    -   `override` (default) - Run the callback with an new empty context.  
-        No values from the parent context will be accessible within the wrapped code.
-    -   `inherit` - Run the callback with a shallow copy of the parent context.  
+    -   `inherit` (default) - Run the callback with a shallow copy of the parent context.  
         Re-assignments of top-level properties will not be reflected in the parent context. However, modifications of existing properties _will_ be reflected.
-    -   `reuse` - Reuse existing context without creating a new one. All modifications to the existing context will be reflected.
+    -   `reuse` - Reuse existing context without creating a new one. All modifications to the
+        existing context will be reflected.
+    -   `override` - Run the callback with an new empty context.  
+        No values from the parent context will be accessible within the wrapped code.
+
+::: Note
+
+Until `v4`, the default behavior was `override`. This was changed to `inherit` since `v4` to make the behavior more intuitive.
+
+:::

--- a/packages/core/src/lib/cls.service.spec.ts
+++ b/packages/core/src/lib/cls.service.spec.ts
@@ -49,7 +49,7 @@ describe('ClsService', () => {
             });
         });
         it('does not retrieve context in a different call (enter)', () => {
-            const runMe = (cb: () => void) => cb();
+            const runMe = (cb: () => void) => service.exit(cb);
             runMe(() => {
                 service.enter();
                 service.set('key', 123);
@@ -181,6 +181,17 @@ describe('ClsService', () => {
     });
 
     describe('nested contexts', () => {
+        it('inherits a copy of context by default', () => {
+            service.run(() => {
+                service.set('key', 'value');
+                service.run(() => {
+                    expect(service.get('key')).toEqual('value');
+                    service.set('key', 'value2');
+                });
+                expect(service.get('key')).toEqual('value');
+            });
+        });
+
         it('creates empty context with the "override" option', () => {
             service.run(() => {
                 service.set('key', 'value');
@@ -191,7 +202,7 @@ describe('ClsService', () => {
             });
         });
 
-        it('creates inherits a copy of context with the "inherit" option', () => {
+        it('inherits a copy of context with the "inherit" option', () => {
             service.run(() => {
                 service.set('key', 'value');
                 service.run({ ifNested: 'inherit' }, () => {
@@ -253,16 +264,21 @@ describe('ClsService', () => {
                 typedService.set('b.d.f', ['x']);
                 typedService.set('b.g', new Map());
                 typedService.set('b.h', { i: 'i', j: 1 });
+                // @ts-expect-error Argument of type '"b.q"' is not assignable to parameter of type 'symbol | "b.h" | "a" | "b" | "b.c" | "b.d" | "b.d.e" | "b.d.f" | "b.g"'.
+                typedService.set('b.q', { i: 'i', j: 1 });
 
                 const { a, b } = typedService.get();
                 a;
                 b;
 
                 typedService.get('a');
+                // @ts-expect-error Argument of type '"q"' is not assignable to parameter of type 'symbol | "b.h" | "a" | "b" | "b.c" | "b.d" | "b.d.e" | "b.d.f" | "b.g" | undefined'.
+                typedService.get('q');
                 typedService.get('b.c');
                 typedService.get('b.d');
                 typedService.get('b.d.e');
                 typedService.get('b.d.f')[0];
+                typedService.get('b.g').get('x');
                 typedService.get('b.g').get('x');
                 const { i, j } = typedService.get('b.h');
                 i;


### PR DESCRIPTION
BREAKING CHANGE: The default of the `ifNested` option was changed from `override` to to `inherit`.

The reason is that users rarely need to use a clean context in the middle of the application if it already contains important details. The more common scenario is to change a part of the context in some section of the code while keeping all other values intact.