### PR TITLE
feat: expose cls.run options on decorator, update defaults

### DIFF
--- a/docs/docs/03_features-and-use-cases/06_proxy-providers.md
+++ b/docs/docs/03_features-and-use-cases/06_proxy-providers.md
@@ -226,7 +226,7 @@ export class CronController {
 
 #### With @UseCls()
 
-The `resolveProxyProviders` is set to `false` by default on the `@UseCls` decorator. To achieve the same behavior using it, you must set it to `true`.
+Since the `@UseCls()` decorator wraps the function body with `cls.run()` automatically, you can use the `setup` function to prepare the context.
 
 The Proxy Providers will be resolved after the `setup` phase.
 
@@ -238,9 +238,8 @@ export class CronController {
     @Cron('45 * * * * *')
     @UseCls({
         // highlight-start
-        resolveProxyProviders: true,
         setup: (cls) => {
-            this.cls.set('some-key', 'some-value');
+            cls.set('some-key', 'some-value');
         },
         // highlight-end
     })

--- a/packages/core/src/lib/cls-initializers/use-cls.decorator.ts
+++ b/packages/core/src/lib/cls-initializers/use-cls.decorator.ts
@@ -44,7 +44,7 @@ export function UseCls<TArgs extends any[]>(
             );
         }
         descriptor.value = function (...args: TArgs) {
-            return cls.run(async () => {
+            return cls.run(options.runOptions ?? {}, async () => {
                 if (options.generateId) {
                     const id = await options.idGenerator?.apply(this, args);
                     cls.set<string>(CLS_ID, id);

--- a/packages/core/src/lib/cls.service.ts
+++ b/packages/core/src/lib/cls.service.ts
@@ -10,22 +10,7 @@ import {
 } from '../types/type-if-type.type';
 import { getValueFromPath, setValueFromPath } from '../utils/value-from-path';
 import { CLS_ID } from './cls.constants';
-import type { ClsStore } from './cls.options';
-
-export class ClsContextOptions {
-    /**
-     * Sets the behavior of nested CLS context creation. Has no effect if no parent context exists.
-     *
-     * `inherit` (default) - Run the callback with a shallow copy of the parent context.
-     * Assignments to top-level properties will not be reflected in the parent context.
-     *
-     * `reuse` - Reuse existing context without creating a new one.
-     *
-     * `override` - Run the callback with an new empty context.
-     * Warning: No values from the parent context will be accessible.
-     */
-    ifNested?: 'inherit' | 'reuse' | 'override' = 'inherit';
-}
+import { ClsContextOptions, ClsStore } from './cls.options';
 
 export class ClsService<S extends ClsStore = ClsStore> {
     constructor(private readonly als: AsyncLocalStorage<any>) {}


### PR DESCRIPTION
Closes #85 

BREAKING CHANGE: The default option for `resolveProxyProviders` was on the `@UseCls` decorator was changed from `false` to `true`