### PR TITLE
feat: add support for transaction propagation modes

### DIFF
--- a/docs/docs/06_plugins/01_available-plugins/01-transactional/index.md
+++ b/docs/docs/06_plugins/01_available-plugins/01-transactional/index.md
@@ -8,6 +8,8 @@ a CLS-enabled transaction by storing the transaction reference in the CLS contex
 
 The transaction reference can be then retrieved in any other service and refer to the same transaction without having to pass it around.
 
+The plugin is designed to be database-agnostic and can be used with any database library that supports transactions (via adapters). At the expense of using a [minimal wrapper](#using-the-transactionhost), it deliberately **does not require any monkey-patching** of the underlying library.
+
 ## Installation
 
 <Tabs>

--- a/packages/transactional/src/index.ts
+++ b/packages/transactional/src/index.ts
@@ -1,6 +1,7 @@
 export * from './lib/transaction-host';
 export * from './lib/transactional.decorator';
 export * from './lib/plugin-transactional';
+export * from './lib/propagation';
 export {
     TransactionalAdapterOptions,
     TransactionalOptionsAdapterFactory,

--- a/packages/transactional/src/lib/propagation.ts
+++ b/packages/transactional/src/lib/propagation.ts
@@ -1,0 +1,56 @@
+/**
+ * Sets the propagation mode for a transaction.
+ */
+export enum Propagation {
+    /**
+     * (default) Reuse the existing transaction or create a new one if none exists.
+     */
+    Required = 'REQUIRED',
+    /**
+     * Create a new transaction even if one already exists.
+     */
+    RequiresNew = 'REQUIRES_NEW',
+    /**
+     * Run without a transaction even if one exists.
+     */
+    NotSupported = 'NOT_SUPPORTED',
+    /**
+     * Reuse an existing transaction, throw an exception otherwise
+     */
+    Mandatory = 'MANDATORY',
+    /**
+     * Throw an exception if an existing transaction exists, otherwise create a new one
+     */
+    Never = 'NEVER',
+}
+
+/**
+ * Base error for transaction propagation errors.
+ */
+export class TransactionPropagationError extends Error {
+    name = TransactionPropagationError.name;
+}
+
+/**
+ * Error thrown when a attempting to start a transaction in mode NEVER, but an existing transaction is already active.
+ */
+export class TransactionAlreadyActiveError extends TransactionPropagationError {
+    name = TransactionAlreadyActiveError.name;
+    constructor(methodName: string) {
+        super(
+            `Trying to start a transaction in mode ${Propagation.Never}, but an existing transaction is already active (for method ${methodName}).`,
+        );
+    }
+}
+
+/**
+ * Error thrown when a attempting to start a transaction in mode MANDATORY, but no existing transaction is active.
+ */
+export class TransactionNotActiveError extends TransactionPropagationError {
+    name = TransactionNotActiveError.name;
+    constructor(methodName?: string) {
+        super(
+            `Trying to start a transaction in mode ${Propagation.Mandatory}, but no existing transaction is active (for method ${methodName}).`,
+        );
+    }
+}

--- a/packages/transactional/src/lib/transaction-host.ts
+++ b/packages/transactional/src/lib/transaction-host.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ClsServiceManager } from 'nestjs-cls';
 import {
     TTxFromAdapter,
@@ -6,17 +6,23 @@ import {
     TransactionalAdapterOptions,
 } from './interfaces';
 import {
+    Propagation,
+    TransactionNotActiveError,
+    TransactionPropagationError,
+} from './propagation';
+import {
     TRANSACTIONAL_ADAPTER_OPTIONS,
     TRANSACTIONAL_INSTANCE,
 } from './symbols';
 
 @Injectable()
 export class TransactionHost<TAdapter = never> {
-    private cls = ClsServiceManager.getClsService();
+    private readonly cls = ClsServiceManager.getClsService();
+    private readonly logger = new Logger(TransactionHost.name);
 
     constructor(
         @Inject(TRANSACTIONAL_ADAPTER_OPTIONS)
-        private _options: TransactionalAdapterOptions<
+        private readonly _options: TransactionalAdapterOptions<
             TTxFromAdapter<TAdapter>,
             TOptionsFromAdapter<TAdapter>
         >,
@@ -51,23 +57,131 @@ export class TransactionHost<TAdapter = never> {
      * @returns Whatever the passed function returns
      */
     withTransaction<R>(fn: (...args: any[]) => Promise<R>): Promise<R>;
+    /**
+     * Wrap a function call in a transaction defined by the adapter.
+     *
+     * The transaction instance will be accessible on the TransactionHost as `tx`.
+     *
+     * This is useful when you want to run a function in a transaction, but can't use the `@Transactional()` decorator.
+     *
+     * @param options Transaction options depending on the adapter.
+     * @param fn The function to run in a transaction.
+     * @returns Whatever the passed function returns
+     */
     withTransaction<R>(
         options: TOptionsFromAdapter<TAdapter>,
         fn: (...args: any[]) => Promise<R>,
     ): Promise<R>;
+    /**
+     * Wrap a function call in a transaction defined by the adapter.
+     *
+     * The transaction instance will be accessible on the TransactionHost as `tx`.
+     *
+     * This is useful when you want to run a function in a transaction, but can't use the `@Transactional()` decorator.
+     *
+     * @param propagation The propagation mode to use, @see{Propagation}.
+     * @param fn The function to run in a transaction.
+     * @returns Whatever the passed function returns
+     */
     withTransaction<R>(
-        optionsOrFn: any,
-        maybeFn?: (...args: any[]) => Promise<R>,
+        propagation: Propagation,
+        fn: (...args: any[]) => Promise<R>,
+    ): Promise<R>;
+    /**
+     * Wrap a function call in a transaction defined by the adapter.
+     *
+     * The transaction instance will be accessible on the TransactionHost as `tx`.
+     *
+     * This is useful when you want to run a function in a transaction, but can't use the `@Transactional()` decorator.
+     *
+     * @param propagation The propagation mode to use, @see{Propagation}.
+     * @param options Transaction options depending on the adapter.
+     * @param fn The function to run in a transaction.
+     * @returns Whatever the passed function returns
+     */
+    withTransaction<R>(
+        propagation: Propagation,
+        options: TOptionsFromAdapter<TAdapter>,
+        fn: (...args: any[]) => Promise<R>,
+    ): Promise<R>;
+    withTransaction<R>(
+        firstParam: any,
+        secondParam?: any,
+        thirdParam?: (...args: any[]) => Promise<R>,
     ) {
+        let propagation: string = Propagation.Required;
         let options: any;
         let fn: (...args: any[]) => Promise<R>;
-        if (maybeFn) {
-            options = optionsOrFn;
-            fn = maybeFn;
+        if (thirdParam) {
+            propagation = firstParam;
+            options = secondParam;
+            fn = thirdParam;
+        } else if (secondParam) {
+            fn = secondParam;
+            if (typeof firstParam === 'string') {
+                propagation = firstParam;
+            } else {
+                options = firstParam;
+            }
         } else {
-            options = {};
-            fn = optionsOrFn;
+            fn = firstParam;
         }
+        return this.decidePropagationAndRun(propagation, options, fn);
+    }
+
+    private decidePropagationAndRun(
+        propagation: string,
+        options: any,
+        fn: (...args: any[]) => Promise<any>,
+    ) {
+        const fnName = fn.name || 'anonymous';
+        switch (propagation) {
+            case Propagation.Required:
+                if (this.isTransactionActive()) {
+                    if (isNotEmpty(options)) {
+                        this.logger.warn(
+                            `Transaction options are ignored because a transaction is already active and the propagation mode is ${propagation} (for method ${fnName}).`,
+                        );
+                    }
+                    return fn();
+                } else {
+                    return this.runWithTransaction(options, fn);
+                }
+            case Propagation.RequiresNew:
+                return this.runWithTransaction(options, fn);
+            case Propagation.NotSupported:
+                if (isNotEmpty(options)) {
+                    this.logger.warn(
+                        `Transaction options are ignored because the propagation mode is ${propagation} (for method ${fnName}).`,
+                    );
+                }
+                return this.withoutTransaction(fn);
+            case Propagation.Mandatory:
+                if (!this.isTransactionActive()) {
+                    throw new TransactionNotActiveError(fnName);
+                }
+                if (isNotEmpty(options)) {
+                    this.logger.warn(
+                        `Transaction options are ignored because the propagation mode is ${propagation} (for method ${fnName}).`,
+                    );
+                }
+                return fn();
+            case Propagation.Never:
+                if (this.isTransactionActive()) {
+                    throw new TransactionNotActiveError(fnName);
+                }
+                return this.runWithTransaction(options, fn);
+            default:
+                throw new TransactionPropagationError(
+                    `Unknown propagation mode ${propagation}`,
+                );
+        }
+    }
+
+    private runWithTransaction(
+        options: any,
+        fn: (...args: any[]) => Promise<any>,
+    ) {
         return this.cls.run({ ifNested: 'inherit' }, () =>
             this._options
                 .wrapWithTransaction(options, fn, this.setTxInstance.bind(this))
@@ -101,4 +215,8 @@ export class TransactionHost<TAdapter = never> {
     private setTxInstance(txInstance?: TTxFromAdapter<TAdapter>) {
         this.cls.set(TRANSACTIONAL_INSTANCE, txInstance);
     }
+}
+
+function isNotEmpty(obj: any) {
+    return obj && Object.keys(obj).length > 0;
 }

--- a/packages/transactional/src/lib/transaction-host.ts
+++ b/packages/transactional/src/lib/transaction-host.ts
@@ -109,7 +109,7 @@ export class TransactionHost<TAdapter = never> {
         secondParam?: any,
         thirdParam?: (...args: any[]) => Promise<R>,
     ) {
-        let propagation: string = Propagation.Required;
+        let propagation: string;
         let options: any;
         let fn: (...args: any[]) => Promise<R>;
         if (thirdParam) {
@@ -126,6 +126,7 @@ export class TransactionHost<TAdapter = never> {
         } else {
             fn = firstParam;
         }
+        propagation ??= Propagation.Required;
         return this.decidePropagationAndRun(propagation, options, fn);
     }
 

--- a/packages/transactional/src/lib/transaction-host.ts
+++ b/packages/transactional/src/lib/transaction-host.ts
@@ -7,6 +7,7 @@ import {
 } from './interfaces';
 import {
     Propagation,
+    TransactionAlreadyActiveError,
     TransactionNotActiveError,
     TransactionPropagationError,
 } from './propagation';
@@ -169,7 +170,7 @@ export class TransactionHost<TAdapter = never> {
                 return fn();
             case Propagation.Never:
                 if (this.isTransactionActive()) {
-                    throw new TransactionNotActiveError(fnName);
+                    throw new TransactionAlreadyActiveError(fnName);
                 }
                 return this.runWithTransaction(options, fn);
             default:

--- a/packages/transactional/src/lib/transactional.decorator.ts
+++ b/packages/transactional/src/lib/transactional.decorator.ts
@@ -4,13 +4,25 @@ import { TOptionsFromAdapter } from './interfaces';
 import { Propagation } from './propagation';
 import { TransactionHost } from './transaction-host';
 
+/**
+ * Run the decorated method in a transaction.
+ *
+ * @param options Transaction options depending on the adapter.
+ */
 export function Transactional<TAdapter>(
     options?: TOptionsFromAdapter<TAdapter>,
 ): MethodDecorator;
+/**
+ * Run the decorated method in a transaction.
+ *
+ * @param propagation The propagation mode to use, @see{Propagation}.
+ * @param options Transaction options depending on the adapter.
+ */
 export function Transactional<TAdapter>(
     propagation: Propagation,
     options?: TOptionsFromAdapter<TAdapter>,
 ): MethodDecorator;
+
 export function Transactional(
     optionsOrPropagation?: any,
     maybeOptions?: any,

--- a/packages/transactional/test/propagation.spec.ts
+++ b/packages/transactional/test/propagation.spec.ts
@@ -1,0 +1,373 @@
+import { Inject, Injectable, Module } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClsModule } from 'nestjs-cls';
+import {
+    ClsPluginTransactional,
+    Propagation,
+    Transactional,
+    TransactionAlreadyActiveError,
+    TransactionHost,
+    TransactionNotActiveError,
+} from '../src';
+import {
+    MockDbConnection,
+    TransactionAdapterMock,
+} from './transaction-adapter-mock';
+
+@Injectable()
+class CalledService {
+    constructor(
+        private readonly txHost: TransactionHost<TransactionAdapterMock>,
+    ) {}
+
+    async doWork(num: number) {
+        return this.txHost.tx.query(`SELECT ${num}`);
+    }
+
+    async doOtherWork(num: number) {
+        return this.txHost.tx.query(`SELECT ${num}`);
+    }
+}
+
+@Injectable()
+class NestedTransactionsService {
+    constructor(private readonly calledService: CalledService) {}
+
+    @Transactional()
+    async withDefaultPropagation(num: number) {
+        return this.calledService.doWork(num);
+    }
+
+    @Transactional(Propagation.Required)
+    async withRequiredPropagation(num: number) {
+        return this.calledService.doWork(num);
+    }
+
+    @Transactional(Propagation.RequiresNew)
+    async withRequiresNewPropagation(num: number) {
+        return this.calledService.doWork(num);
+    }
+
+    @Transactional(Propagation.NotSupported)
+    async withNotSupportedPropagation(num: number) {
+        return this.calledService.doWork(num);
+    }
+
+    @Transactional(Propagation.Mandatory)
+    async withMandatoryPropagation(num: number) {
+        return this.calledService.doWork(num);
+    }
+
+    @Transactional(Propagation.Never)
+    async withNeverPropagation(num: number) {
+        return this.calledService.doWork(num);
+    }
+}
+
+@Injectable()
+class CallingServiceWithoutTransaction {
+    @Inject(CalledService)
+    protected readonly calledService: CalledService;
+    @Inject(TransactionHost)
+    protected readonly txHost: TransactionHost<TransactionAdapterMock>;
+    @Inject(NestedTransactionsService)
+    protected readonly nested: NestedTransactionsService;
+
+    async defaultPropagation() {
+        await this.calledService.doWork(1);
+        await this.nested.withDefaultPropagation(2);
+    }
+
+    async explicitRequiredPropagation() {
+        await this.calledService.doWork(3);
+        await this.nested.withRequiredPropagation(4);
+    }
+
+    async requiresNewPropagation() {
+        await this.calledService.doWork(5);
+        await this.nested.withRequiresNewPropagation(6);
+    }
+
+    async notSupportedPropagation() {
+        await this.calledService.doWork(7);
+        await this.nested.withNotSupportedPropagation(8);
+    }
+    async mandatoryPropagation() {
+        await this.calledService.doWork(9);
+        await this.nested.withMandatoryPropagation(10);
+    }
+    async neverPropagation() {
+        await this.calledService.doWork(11);
+        await this.nested.withNeverPropagation(12);
+    }
+}
+
+@Injectable()
+class CallingServiceWithTransaction extends CallingServiceWithoutTransaction {
+    @Transactional()
+    defaultPropagation(): Promise<void> {
+        return super.defaultPropagation();
+    }
+    @Transactional()
+    explicitRequiredPropagation(): Promise<void> {
+        return super.explicitRequiredPropagation();
+    }
+    @Transactional()
+    requiresNewPropagation(): Promise<void> {
+        return super.requiresNewPropagation();
+    }
+    @Transactional()
+    notSupportedPropagation(): Promise<void> {
+        return super.notSupportedPropagation();
+    }
+    @Transactional()
+    mandatoryPropagation(): Promise<void> {
+        return super.mandatoryPropagation();
+    }
+    @Transactional()
+    neverPropagation(): Promise<void> {
+        return super.neverPropagation();
+    }
+
+    @Transactional<TransactionAdapterMock>(Propagation.NotSupported, {
+        serializable: true,
+    })
+    async multipleNestedTransactions() {
+        await this.calledService.doWork(10);
+        await this.requiredPropagationWithOptions(11);
+        await this.txHost.withTransaction(
+            Propagation.RequiresNew,
+            {
+                serializable: true,
+            },
+            async () => {
+                await this.nested.withRequiresNewPropagation(12);
+                await this.defaultPropagationWithOptions(13);
+                await this.calledService.doWork(14);
+                await this.mandatoryPropagationWithOptions(15);
+                throw new Error('Bad thing');
+            },
+        );
+    }
+
+    @Transactional<TransactionAdapterMock>(Propagation.Required, {
+        serializable: true,
+    })
+    private async requiredPropagationWithOptions(num: number) {
+        return this.nested.withRequiredPropagation(num);
+    }
+
+    @Transactional<TransactionAdapterMock>({
+        serializable: true,
+    })
+    private async defaultPropagationWithOptions(num: number) {
+        return this.nested.withRequiredPropagation(num);
+    }
+
+    @Transactional<TransactionAdapterMock>(Propagation.Mandatory, {
+        serializable: true,
+    })
+    private async mandatoryPropagationWithOptions(num: number) {
+        return this.nested.withRequiredPropagation(num);
+    }
+}
+
+@Module({
+    providers: [MockDbConnection],
+    exports: [MockDbConnection],
+})
+class DbConnectionModule {}
+
+@Module({
+    imports: [
+        ClsModule.forRoot({
+            plugins: [
+                new ClsPluginTransactional({
+                    imports: [DbConnectionModule],
+                    adapter: new TransactionAdapterMock({
+                        connectionToken: MockDbConnection,
+                    }),
+                }),
+            ],
+        }),
+    ],
+    providers: [
+        CallingServiceWithoutTransaction,
+        CallingServiceWithTransaction,
+        NestedTransactionsService,
+        CalledService,
+    ],
+})
+class AppModule {}
+
+const mockLogger = {
+    ...console,
+    warn: jest.fn(),
+};
+
+describe('Propagation', () => {
+    let module: TestingModule;
+    let withoutTx: CallingServiceWithoutTransaction;
+    let withTx: CallingServiceWithTransaction;
+    let mockDbConnection: MockDbConnection;
+    beforeEach(async () => {
+        module = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+        await module.init();
+        module.useLogger(mockLogger);
+        withoutTx = module.get(CallingServiceWithoutTransaction);
+        withTx = module.get(CallingServiceWithTransaction);
+        mockDbConnection = module.get(MockDbConnection);
+    });
+
+    describe('when run without an existing transaction', () => {
+        it('should create a new transaction by default', async () => {
+            await withoutTx.defaultPropagation();
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([
+                ['SELECT 1'],
+                ['BEGIN TRANSACTION;', 'SELECT 2', 'COMMIT TRANSACTION;'],
+            ]);
+        });
+        it('should create a new transaction in REQUIRED mode', async () => {
+            await withoutTx.explicitRequiredPropagation();
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([
+                ['SELECT 3'],
+                ['BEGIN TRANSACTION;', 'SELECT 4', 'COMMIT TRANSACTION;'],
+            ]);
+        });
+        it('should create a new transaction in REQUIRES_NEW mode', async () => {
+            await withoutTx.requiresNewPropagation();
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([
+                ['SELECT 5'],
+                ['BEGIN TRANSACTION;', 'SELECT 6', 'COMMIT TRANSACTION;'],
+            ]);
+        });
+        it('should not start a transaction in NOT_SUPPORTED mode', async () => {
+            await withoutTx.notSupportedPropagation();
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([['SELECT 7'], ['SELECT 8']]);
+        });
+        it('should throw a TransactionNotActiveError error in MANDATORY mode', async () => {
+            await expect(withoutTx.mandatoryPropagation()).rejects.toThrow(
+                TransactionNotActiveError,
+            );
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([['SELECT 9']]);
+        });
+        it('should not start a transaction in NEVER mode', async () => {
+            await withoutTx.neverPropagation();
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([
+                ['SELECT 11'],
+                ['BEGIN TRANSACTION;', 'SELECT 12', 'COMMIT TRANSACTION;'],
+            ]);
+        });
+    });
+
+    describe('when run in an existing transaction', () => {
+        it('should re-use an existing transaction by default', async () => {
+            await withTx.defaultPropagation();
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([
+                [
+                    'BEGIN TRANSACTION;',
+                    'SELECT 1',
+                    'SELECT 2',
+                    'COMMIT TRANSACTION;',
+                ],
+            ]);
+        });
+        it('should re-use an existing transaction in REQUIRED mode', async () => {
+            await withTx.explicitRequiredPropagation();
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([
+                [
+                    'BEGIN TRANSACTION;',
+                    'SELECT 3',
+                    'SELECT 4',
+                    'COMMIT TRANSACTION;',
+                ],
+            ]);
+        });
+        it('should create a new transaction in REQUIRES_NEW mode', async () => {
+            await withTx.requiresNewPropagation();
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([
+                ['BEGIN TRANSACTION;', 'SELECT 5', 'COMMIT TRANSACTION;'],
+                ['BEGIN TRANSACTION;', 'SELECT 6', 'COMMIT TRANSACTION;'],
+            ]);
+        });
+        it('should run the nested function without a transaction in NOT_SUPPORTED mode', async () => {
+            await withTx.notSupportedPropagation();
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([
+                ['BEGIN TRANSACTION;', 'SELECT 7', 'COMMIT TRANSACTION;'],
+                ['SELECT 8'],
+            ]);
+        });
+        it('should re-use the existing transaction in MANDATORY mode', async () => {
+            await withTx.mandatoryPropagation();
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([
+                [
+                    'BEGIN TRANSACTION;',
+                    'SELECT 9',
+                    'SELECT 10',
+                    'COMMIT TRANSACTION;',
+                ],
+            ]);
+        });
+        it('should throw a TransactionAlreadyActiveError and rollback in NEVER mode', async () => {
+            await expect(withTx.neverPropagation()).rejects.toThrow(
+                TransactionAlreadyActiveError,
+            );
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([
+                ['BEGIN TRANSACTION;', 'SELECT 11', 'ROLLBACK TRANSACTION;'],
+            ]);
+        });
+    });
+
+    describe('when multiple nested transactions with different options are used', () => {
+        it('should behave according to the settings', async () => {
+            await expect(withTx.multipleNestedTransactions()).rejects.toThrow(
+                'Bad thing',
+            );
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([
+                ['SELECT 10'],
+                [
+                    'SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; BEGIN TRANSACTION;',
+                    'SELECT 11',
+                    'COMMIT TRANSACTION;',
+                ],
+                [
+                    'SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; BEGIN TRANSACTION;',
+                    'SELECT 13',
+                    'SELECT 14',
+                    'SELECT 15',
+                    'ROLLBACK TRANSACTION;',
+                ],
+                ['BEGIN TRANSACTION;', 'SELECT 12', 'COMMIT TRANSACTION;'],
+            ]);
+            expect(mockLogger.warn.mock.calls).toEqual([
+                [
+                    'Transaction options are ignored because the propagation mode is NOT_SUPPORTED (for method bound multipleNestedTransactions).',
+                    'TransactionHost',
+                ],
+                [
+                    'Transaction options are ignored because a transaction is already active and the propagation mode is REQUIRED (for method bound defaultPropagationWithOptions).',
+                    'TransactionHost',
+                ],
+                [
+                    'Transaction options are ignored because the propagation mode is MANDATORY (for method bound mandatoryPropagationWithOptions).',
+                    'TransactionHost',
+                ],
+            ]);
+        });
+    });
+});

--- a/packages/transactional/test/transactional.spec.ts
+++ b/packages/transactional/test/transactional.spec.ts
@@ -20,10 +20,6 @@ class CalledService {
     async doOtherWork(num: number) {
         return this.txHost.tx.query(`SELECT ${num}`);
     }
-
-    getPerformedOperations() {
-        return this.txHost.tx.operations;
-    }
 }
 
 @Injectable()
@@ -212,23 +208,6 @@ describe('Transactional', () => {
             await callingService.withoutTransaction();
             const queries = mockDbConnection.getClientsQueries();
             expect(queries).toEqual([['SELECT 5'], ['SELECT 6']]);
-        });
-    });
-
-    describe('when using nested transactions', () => {
-        it('should start a transaction', async () => {
-            await callingService.multipleNestedTransactions();
-            const queries = mockDbConnection.getClientsQueries();
-            expect(queries).toEqual([
-                ['BEGIN TRANSACTION;', 'SELECT 10', 'COMMIT TRANSACTION;'],
-                [
-                    'BEGIN TRANSACTION;',
-                    'SELECT 11',
-                    'SELECT 13',
-                    'COMMIT TRANSACTION;',
-                ],
-                ['BEGIN TRANSACTION;', 'SELECT 12', 'COMMIT TRANSACTION;'],
-            ]);
         });
     });
 });


### PR DESCRIPTION
Closes #108 

BREAKING CHANGE: The default mode is now `REQUIRED` which re-uses the transaction if one exists, while previously a new one was always started.