### PR TITLE
fix: symbol key access and explicit constructor error

### DIFF
--- a/packages/core/src/lib/cls.service.spec.ts
+++ b/packages/core/src/lib/cls.service.spec.ts
@@ -143,6 +143,14 @@ describe('ClsService', () => {
                 expect(service.has(sym)).toEqual(true);
             });
         });
+
+        it('checks key presence without context (string key)', () => {
+            expect(service.has('d')).toEqual(false);
+        });
+
+        it('checks key presence without context (symbol key)', () => {
+            expect(service.has(Symbol('sym'))).toEqual(false);
+        });
     });
 
     describe('edge cases', () => {
@@ -151,6 +159,18 @@ describe('ClsService', () => {
                 const value = service.get('key');
                 expect(value).toBeUndefined();
             });
+        });
+
+        it('returns undefined if trying to get a value without context (string key)', () => {
+            expect(service.get('key')).toBeUndefined();
+        });
+
+        it('returns undefined if trying to get a value without context (symbol key)', () => {
+            expect(service.get(Symbol('xx'))).toBeUndefined();
+        });
+
+        it('returns undefined if trying to get request ID without context (symbol key)', () => {
+            expect(service.getId()).toBeUndefined();
         });
 
         it('throws error if trying to set a value without context', () => {
@@ -230,6 +250,12 @@ describe('ClsService', () => {
                 expect(service.get('key')).toEqual('value');
             });
             expect(service.get('key')).toEqual(undefined);
+        });
+    });
+
+    describe('manual creation', () => {
+        it('should fail with error', () => {
+            expect(() => new ClsService(undefined as any)).toThrowError();
         });
     });
 

--- a/packages/core/src/lib/cls.service.ts
+++ b/packages/core/src/lib/cls.service.ts
@@ -13,7 +13,13 @@ import { CLS_ID } from './cls.constants';
 import { ClsContextOptions, ClsStore } from './cls.options';
 
 export class ClsService<S extends ClsStore = ClsStore> {
-    constructor(private readonly als: AsyncLocalStorage<any>) {}
+    constructor(private readonly als: AsyncLocalStorage<any>) {
+        if (!als) {
+            throw new Error(
+                `Cannot create ClsService because no AsyncLocalStorage instance was provided.\nPlease make sure that ClsService is only provided by the ClsModule and not constructed manually or added to the providers array.`,
+            );
+        }
+    }
 
     /**
      * Set (or overrides) a value on the CLS context.
@@ -79,7 +85,7 @@ export class ClsService<S extends ClsStore = ClsStore> {
         const store = this.als.getStore();
         if (!key) return store;
         if (typeof key === 'symbol') {
-            return store[key];
+            return store?.[key];
         }
         return getValueFromPath(store as S, key as any) as any;
     }
@@ -95,7 +101,7 @@ export class ClsService<S extends ClsStore = ClsStore> {
     has(key: string | symbol): boolean {
         const store = this.als.getStore();
         if (typeof key === 'symbol') {
-            return store[key] !== undefined;
+            return store?.[key] !== undefined;
         }
         return getValueFromPath(store as S, key as any) !== undefined;
     }


### PR DESCRIPTION
* When accessing symbol keys without context, an error is no longer thrown.

* When creating ClsService without passing als, an error is thrown immediately.