### PR TITLE
fix(core): handle nested context correctly with UseCls decorator

### DIFF
--- a/packages/core/src/lib/cls-initializers/use-cls.decorator.spec.ts
+++ b/packages/core/src/lib/cls-initializers/use-cls.decorator.spec.ts
@@ -4,6 +4,7 @@ import { CLS_ID } from '../cls.constants';
 import { ClsModule } from '../cls.module';
 import { ClsService } from '../cls.service';
 import { UseCls } from './use-cls.decorator';
+import { ClsServiceManager } from '../cls-service-manager';
 
 @Injectable()
 class TestClass {
@@ -38,6 +39,7 @@ class TestClass {
         return {
             id: this.cls.getId(),
             value: this.cls.get('value'),
+            inheritedValue: this.cls.get('inheritedValue'),
         };
     }
 }
@@ -61,6 +63,20 @@ describe('@UseCls', () => {
             value: 'something',
         });
     });
+
+    it('should handle nested context', async () => {
+        const cls = ClsServiceManager.getClsService();
+        await cls.run(async () => {
+            cls.set('inheritedValue', 'other');
+            const result = await testClass.startContext('something');
+            expect(result).toEqual({
+                id: 'the-id',
+                value: 'something',
+                inheritedValue: 'other',
+            });
+        });
+    });
+
     it('calls id generator and setup and uses correct this', async () => {
         const result = await testClass.startContextWithIdAndSetup(
             'something else',

--- a/packages/core/src/lib/cls.service.ts
+++ b/packages/core/src/lib/cls.service.ts
@@ -125,10 +125,10 @@ export class ClsService<S extends ClsStore = ClsStore> {
         let options: ClsContextOptions;
         let callback: () => any;
         if (typeof optionsOrCallback === 'object') {
-            options = optionsOrCallback;
+            options = { ...new ClsContextOptions(), ...optionsOrCallback };
             callback = maybeCallback;
         } else {
-            options = { ...new ClsContextOptions(), ...optionsOrCallback };
+            options = new ClsContextOptions();
             callback = optionsOrCallback;
         }
         if (!this.isActive()) return this.runWith({} as S, callback);


### PR DESCRIPTION
## Issue

Methods decorated with `@UseCls()` (without `runOptions`) are not called when running inside a parent context.

## Fix

This PR prepends the default options to the options passed down to the `cls.run(options, callback)` function. This way, `options.ifNested` is always defined (default to `inherit`), and the callback is always triggered in the `switch (options.ifNested) ... case` block.

Since `@UseCls()` calls `run` with an empty options object: `cls.run({}, callback)` ; it fixes the issue 👍