### PR TITLE
feat: add option to inject tx directly as Proxy

### DIFF
--- a/packages/core/src/lib/proxy-provider/proxy-provider-manager.ts
+++ b/packages/core/src/lib/proxy-provider/proxy-provider-manager.ts
@@ -88,14 +88,21 @@ export class ProxyProviderManager {
         const getProvider = () => this.clsService.get()?.[providerKey] ?? {};
         const baseType = type === 'function' ? () => null : {};
         return new Proxy(baseType, {
-            apply(_, thisArg, argArray) {
-                return getProvider().apply(thisArg, argArray);
+            apply(_, __, argArray) {
+                const provider = getProvider();
+                return provider.apply(provider, argArray);
             },
-            get(_, prop) {
-                return getProvider()[prop];
+            get(_, propName) {
+                const provider = getProvider();
+                const prop = provider[propName];
+                if (typeof prop === 'function') {
+                    return prop.bind(provider);
+                } else {
+                    return prop;
+                }
             },
-            set(_, prop, value) {
-                return Reflect.set(getProvider(), prop, value);
+            set(_, propName, value) {
+                return Reflect.set(getProvider(), propName, value);
             },
             ownKeys() {
                 return Reflect.ownKeys(getProvider());

--- a/packages/transactional-adapters/transactional-adapter-knex/test/transactional-adapter-knex.spec.ts
+++ b/packages/transactional-adapters/transactional-adapter-knex/test/transactional-adapter-knex.spec.ts
@@ -1,5 +1,7 @@
 import {
     ClsPluginTransactional,
+    InjectTransaction,
+    Transaction,
     Transactional,
     TransactionHost,
 } from '@nestjs-cls/transactional';
@@ -14,16 +16,16 @@ const KNEX = 'KNEX';
 @Injectable()
 class UserRepository {
     constructor(
-        private readonly txHost: TransactionHost<TransactionalAdapterKnex>,
+        @InjectTransaction()
+        private readonly tx: Transaction<TransactionalAdapterKnex>,
     ) {}
 
     async getUserById(id: number) {
-        return this.txHost.tx('user').where({ id }).first();
+        return this.tx('user').where({ id }).first();
     }
 
     async createUser(name: string) {
-        const created = await this.txHost
-            .tx('user')
+        const created = await this.tx('user')
             .insert({ name: name, email: `${name}@email.com` })
             .returning('*');
         return created[0] ?? null;
@@ -110,6 +112,7 @@ class KnexModule {}
                     adapter: new TransactionalAdapterKnex({
                         knexInstanceToken: KNEX,
                     }),
+                    enableTransactionProxy: true,
                 }),
             ],
         }),

--- a/packages/transactional-adapters/transactional-adapter-kysely/test/transactional-adapter-kysely.spec.ts
+++ b/packages/transactional-adapters/transactional-adapter-kysely/test/transactional-adapter-kysely.spec.ts
@@ -1,5 +1,7 @@
 import {
     ClsPluginTransactional,
+    InjectTransaction,
+    Transaction,
     Transactional,
     TransactionHost,
 } from '@nestjs-cls/transactional';
@@ -26,13 +28,12 @@ interface User {
 @Injectable()
 class UserRepository {
     constructor(
-        private readonly txHost: TransactionHost<
-            TransactionalAdapterKysely<Database>
-        >,
+        @InjectTransaction()
+        private readonly tx: Transaction<TransactionalAdapterKysely<Database>>,
     ) {}
 
     async getUserById(id: number) {
-        return this.txHost.tx
+        return this.tx
             .selectFrom('user')
             .where('id', '=', id)
             .selectAll()
@@ -40,7 +41,7 @@ class UserRepository {
     }
 
     async createUser(name: string) {
-        return this.txHost.tx
+        return this.tx
             .insertInto('user')
             .values({
                 name: name,
@@ -138,6 +139,7 @@ class KnexModule {}
                     adapter: new TransactionalAdapterKysely({
                         kyselyInstanceToken: KYSELY,
                     }),
+                    enableTransactionProxy: true,
                 }),
             ],
         }),

--- a/packages/transactional-adapters/transactional-adapter-prisma/test/transactional-adapter-prisma.spec.ts
+++ b/packages/transactional-adapters/transactional-adapter-prisma/test/transactional-adapter-prisma.spec.ts
@@ -1,5 +1,7 @@
 import {
     ClsPluginTransactional,
+    InjectTransaction,
+    Transaction,
     Transactional,
     TransactionHost,
 } from '@nestjs-cls/transactional';
@@ -13,15 +15,16 @@ import { TransactionalAdapterPrisma } from '../src';
 @Injectable()
 class UserRepository {
     constructor(
-        private readonly txHost: TransactionHost<TransactionalAdapterPrisma>,
+        @InjectTransaction()
+        private readonly tx: Transaction<TransactionalAdapterPrisma>,
     ) {}
 
     async getUserById(id: number) {
-        return this.txHost.tx.user.findUnique({ where: { id } });
+        return this.tx.user.findUnique({ where: { id } });
     }
 
     async createUser(name: string) {
-        return this.txHost.tx.user.create({
+        return this.tx.user.create({
             data: { name: name, email: `${name}@email.com` },
         });
     }
@@ -93,6 +96,7 @@ class PrismaModule {}
                     adapter: new TransactionalAdapterPrisma({
                         prismaInjectionToken: PrismaClient,
                     }),
+                    enableTransactionProxy: true,
                 }),
             ],
         }),

--- a/packages/transactional/src/index.ts
+++ b/packages/transactional/src/index.ts
@@ -2,9 +2,11 @@ export * from './lib/transaction-host';
 export * from './lib/transactional.decorator';
 export * from './lib/plugin-transactional';
 export * from './lib/propagation';
+export * from './lib/inject-transaction.decorator';
 export {
     TransactionalAdapterOptions,
     TransactionalOptionsAdapterFactory,
     TransactionalAdapter,
     TransactionalPluginOptions,
+    Transaction,
 } from './lib/interfaces';

--- a/packages/transactional/src/lib/inject-transaction.decorator.ts
+++ b/packages/transactional/src/lib/inject-transaction.decorator.ts
@@ -1,0 +1,23 @@
+import { Inject } from '@nestjs/common';
+const TRANSACTION_TOKEN = Symbol('TRANSACTION_TOKEN');
+
+/**
+ * Get injection token for the Transaction instance.
+ * If name is omitted, the default instance is used.
+ */
+export function getTransactionToken(connectionName?: string) {
+    return connectionName
+        ? Symbol.for(`${TRANSACTION_TOKEN.description}_${connectionName}`)
+        : TRANSACTION_TOKEN;
+}
+
+/**
+ * Inject the Transaction instance directly (that is the `tx` property of the TransactionHost)
+ *
+ * Optionally, you can provide a connection name to inject a named instance.
+ *
+ * A shorthand for `Inject(getTransactionToken(connectionName))`
+ */
+export function InjectTransaction(connectionName?: string) {
+    return Inject(getTransactionToken(connectionName));
+}

--- a/packages/transactional/src/lib/interfaces.ts
+++ b/packages/transactional/src/lib/interfaces.ts
@@ -7,9 +7,10 @@ export interface TransactionalAdapterOptions<TTx, TOptions> {
     getFallbackInstance: () => TTx;
 }
 
-export interface TransactionalAdapterOptionsWithName<TTx, TOptions>
+export interface MergedTransactionalAdapterOptions<TTx, TOptions>
     extends TransactionalAdapterOptions<TTx, TOptions> {
-    connectionName: string;
+    connectionName: string | undefined;
+    enableTransactionProxy: boolean;
 }
 
 export type TransactionalOptionsAdapterFactory<TConnection, TTx, TOptions> = (
@@ -49,6 +50,12 @@ export interface TransactionalPluginOptions<TConnection, TTx, TOptions> {
      * An optional name of the connection. Useful when there are multiple TransactionalPlugins registered in the app.
      */
     connectionName?: string;
+    /**
+     * Whether to enable injecting the Transaction instance directly using `@InjectTransaction()`
+     *
+     * Default: `true`
+     */
+    enableTransactionProxy?: boolean;
 }
 
 export type TTxFromAdapter<TAdapter> = TAdapter extends TransactionalAdapter<
@@ -63,3 +70,6 @@ export type TOptionsFromAdapter<TAdapter> =
     TAdapter extends TransactionalAdapter<any, any, infer TOptions>
         ? TOptions
         : never;
+
+export type Transaction<TAdapter extends TransactionalAdapter<any, any, any>> =
+    TTxFromAdapter<TAdapter>;

--- a/packages/transactional/src/lib/interfaces.ts
+++ b/packages/transactional/src/lib/interfaces.ts
@@ -53,7 +53,7 @@ export interface TransactionalPluginOptions<TConnection, TTx, TOptions> {
     /**
      * Whether to enable injecting the Transaction instance directly using `@InjectTransaction()`
      *
-     * Default: `true`
+     * Default: `false`
      */
     enableTransactionProxy?: boolean;
 }

--- a/packages/transactional/src/lib/symbols.ts
+++ b/packages/transactional/src/lib/symbols.ts
@@ -1,9 +1,9 @@
 export const TRANSACTION_CONNECTION = Symbol('TRANSACTION_CONNECTION');
 export const TRANSACTIONAL_ADAPTER_OPTIONS = Symbol('TRANSACTIONAL_OPTIONS');
 
-const TRANSACTIONAL_INSTANCE = Symbol('TRANSACTIONAL_CLIENT');
+const TRANSACTION_CLS_KEY = Symbol('TRANSACTION_CLS_KEY');
 
-export const getTransactionalInstanceSymbol = (connectionName?: string) =>
+export const getTransactionClsKey = (connectionName?: string) =>
     connectionName
-        ? Symbol.for(`${TRANSACTIONAL_INSTANCE.toString()}_${connectionName}`)
-        : TRANSACTIONAL_INSTANCE;
+        ? Symbol.for(`${TRANSACTION_CLS_KEY.description}_${connectionName}`)
+        : TRANSACTION_CLS_KEY;

--- a/packages/transactional/test/inject-transaction.spec.ts
+++ b/packages/transactional/test/inject-transaction.spec.ts
@@ -1,0 +1,203 @@
+import { Injectable, Module } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClsModule, UseCls } from 'nestjs-cls';
+import {
+    ClsPluginTransactional,
+    InjectTransaction,
+    InjectTransactionHost,
+    Transaction,
+    Transactional,
+    TransactionHost,
+} from '../src';
+import {
+    MockDbConnection,
+    TransactionAdapterMock,
+} from './transaction-adapter-mock';
+
+class CalledService {
+    constructor(private readonly tx: Transaction<TransactionAdapterMock>) {}
+
+    async doWork(num: number) {
+        return this.tx.query(`SELECT ${num}`);
+    }
+}
+
+@Injectable()
+class CalledService1 extends CalledService {
+    constructor(
+        @InjectTransaction('named-connection')
+        txHost: Transaction<TransactionAdapterMock>,
+    ) {
+        super(txHost);
+    }
+}
+
+@Injectable()
+class CalledService2 extends CalledService {
+    constructor(
+        @InjectTransaction()
+        txHost: Transaction<TransactionAdapterMock>,
+    ) {
+        super(txHost);
+    }
+}
+
+@Injectable()
+class CallingService {
+    constructor(
+        private readonly calledService1: CalledService1,
+        private readonly calledService2: CalledService2,
+        @InjectTransactionHost('named-connection')
+        private readonly txHost1: TransactionHost<TransactionAdapterMock>,
+        @InjectTransactionHost()
+        private readonly txHost2: TransactionHost<TransactionAdapterMock>,
+    ) {}
+
+    @UseCls()
+    async twoUnrelatedTransactionsWithDecorators() {
+        const [q1, q2] = await Promise.all([
+            this.nestedStartTransaction1(1),
+            this.nestedStartTransaction2(2),
+        ]);
+        return { q1, q2 };
+    }
+
+    @Transactional('named-connection')
+    private async nestedStartTransaction1(num: number) {
+        return this.calledService1.doWork(num);
+    }
+
+    // @UseCls()
+    @Transactional()
+    private async nestedStartTransaction2(num: number) {
+        return this.calledService2.doWork(num);
+    }
+
+    // @UseCls()
+    async twoUnrelatedTransactionsWithStartTransaction() {
+        const [q1, q2] = await Promise.all([
+            this.txHost1.withTransaction(() => this.calledService1.doWork(3)),
+            this.txHost2.withTransaction(() => this.calledService2.doWork(4)),
+        ]);
+        return { q1, q2 };
+    }
+
+    @UseCls()
+    @Transactional('named-connection')
+    async namedTransactionWithinAnotherNamedTransaction() {
+        const q1 = await this.calledService1.doWork(5);
+        const q2 = await this.calledService2.doWork(6);
+        const q3 = await this.nestedStartTransaction2(7);
+        return { q1, q2, q3 };
+    }
+}
+
+class MockDbConnection2 extends MockDbConnection {}
+class MockDbConnection1 extends MockDbConnection {}
+
+@Module({
+    providers: [MockDbConnection1],
+    exports: [MockDbConnection1],
+})
+class DbConnectionModule1 {}
+
+@Module({
+    providers: [MockDbConnection2],
+    exports: [MockDbConnection2],
+})
+class DbConnectionModule2 {}
+
+@Module({
+    imports: [
+        ClsModule.forRoot({
+            plugins: [
+                new ClsPluginTransactional({
+                    connectionName: 'named-connection',
+                    enableTransactionProxy: true,
+                    imports: [DbConnectionModule1],
+                    adapter: new TransactionAdapterMock({
+                        connectionToken: MockDbConnection1,
+                    }),
+                }),
+                new ClsPluginTransactional({
+                    enableTransactionProxy: true,
+                    imports: [DbConnectionModule2],
+                    adapter: new TransactionAdapterMock({
+                        connectionToken: MockDbConnection2,
+                    }),
+                }),
+            ],
+        }),
+    ],
+    providers: [CallingService, CalledService1, CalledService2],
+})
+class AppModule {}
+
+describe('InjectTransaction with multiple named connections', () => {
+    let module: TestingModule;
+    let callingService: CallingService;
+    let mockDbConnection1: MockDbConnection;
+    let mockDbConnection2: MockDbConnection;
+    beforeEach(async () => {
+        module = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+        await module.init();
+        callingService = module.get(CallingService);
+        mockDbConnection1 = module.get(MockDbConnection1);
+        mockDbConnection2 = module.get(MockDbConnection2);
+    });
+
+    describe('when using the @Transactional decorator', () => {
+        it('should start two transactions independently with decorator', async () => {
+            const result =
+                await callingService.twoUnrelatedTransactionsWithDecorators();
+            expect(result).toEqual({
+                q1: { query: 'SELECT 1' },
+                q2: { query: 'SELECT 2' },
+            });
+            const queries1 = mockDbConnection1.getClientsQueries();
+            expect(queries1).toEqual([
+                ['BEGIN TRANSACTION;', 'SELECT 1', 'COMMIT TRANSACTION;'],
+            ]);
+            const queries2 = mockDbConnection2.getClientsQueries();
+            expect(queries2).toEqual([
+                ['BEGIN TRANSACTION;', 'SELECT 2', 'COMMIT TRANSACTION;'],
+            ]);
+        });
+        it('should start two transactions independently with startTransaction', async () => {
+            const result =
+                await callingService.twoUnrelatedTransactionsWithStartTransaction();
+            expect(result).toEqual({
+                q1: { query: 'SELECT 3' },
+                q2: { query: 'SELECT 4' },
+            });
+            const queries1 = mockDbConnection1.getClientsQueries();
+            expect(queries1).toEqual([
+                ['BEGIN TRANSACTION;', 'SELECT 3', 'COMMIT TRANSACTION;'],
+            ]);
+            const queries2 = mockDbConnection2.getClientsQueries();
+            expect(queries2).toEqual([
+                ['BEGIN TRANSACTION;', 'SELECT 4', 'COMMIT TRANSACTION;'],
+            ]);
+        });
+        it('ignore transactions for other named connection', async () => {
+            const result =
+                await callingService.namedTransactionWithinAnotherNamedTransaction();
+            expect(result).toEqual({
+                q1: { query: 'SELECT 5' },
+                q2: { query: 'SELECT 6' },
+                q3: { query: 'SELECT 7' },
+            });
+            const queries1 = mockDbConnection1.getClientsQueries();
+            expect(queries1).toEqual([
+                ['BEGIN TRANSACTION;', 'SELECT 5', 'COMMIT TRANSACTION;'],
+            ]);
+            const queries2 = mockDbConnection2.getClientsQueries();
+            expect(queries2).toEqual([
+                ['SELECT 6'],
+                ['BEGIN TRANSACTION;', 'SELECT 7', 'COMMIT TRANSACTION;'],
+            ]);
+        });
+    });
+});

--- a/packages/transactional/test/transaction-adapter-mock.ts
+++ b/packages/transactional/test/transaction-adapter-mock.ts
@@ -22,7 +22,9 @@ export class MockDbConnection {
     }
 
     getClientsQueries() {
-        return this.clients.map((c) => c.operations);
+        return this.clients
+            .map((c) => c.operations)
+            .filter((o) => o.length > 0);
     }
 }
 


### PR DESCRIPTION
Adds the option to use `@InjectTransaction` to inject a Proxy of the transaction instance instead of the `TransactionHost`.