### PR TITLE
PgPromise adapter: add default tx options

### DIFF
--- a/docs/docs/06_plugins/01_available-plugins/01-transactional/04-pg-promise-adapter.md
+++ b/docs/docs/06_plugins/01_available-plugins/01-transactional/04-pg-promise-adapter.md
@@ -32,6 +32,8 @@ pnpm add @nestjs-cls/transactional-adapter-pg-promise
 ## Registration
 
 ```ts
+import { txMode } from 'pg-promise'
+
 ClsModule.forRoot({
     plugins: [
         new ClsPluginTransactional({
@@ -42,6 +44,9 @@ ClsModule.forRoot({
             adapter: new TransactionalAdapterPgPromise({
                 // the injection token of the database instance
                 dbInstanceToken: DB,
+
+                // default transaction options (optional)
+                defaultTxOptions: { mode: new txMode.TransactionMode({ tiLevel: txMode.isolationLevel.serializable }) }
             }),
         }),
     ],

--- a/docs/docs/06_plugins/01_available-plugins/01-transactional/04-pg-promise-adapter.md
+++ b/docs/docs/06_plugins/01_available-plugins/01-transactional/04-pg-promise-adapter.md
@@ -57,8 +57,6 @@ ClsModule.forRoot({
 
 The `tx` property on the `TransactionHost<TransactionalAdapterPgPromise>` is typed as [`Database`](https://vitaly-t.github.io/pg-promise/Database.html).
 
-`@Transactional()` takes an optional argument that is the same as the `option` argument to `Database.tx()` in `pg-promise` ([docs](https://vitaly-t.github.io/pg-promise/Database.html#tx)).
-
 ## Example
 
 ```ts title="user.service.ts"

--- a/docs/docs/06_plugins/01_available-plugins/01-transactional/04-pg-promise-adapter.md
+++ b/docs/docs/06_plugins/01_available-plugins/01-transactional/04-pg-promise-adapter.md
@@ -57,6 +57,8 @@ ClsModule.forRoot({
 
 The `tx` property on the `TransactionHost<TransactionalAdapterPgPromise>` is typed as [`Database`](https://vitaly-t.github.io/pg-promise/Database.html).
 
+`@Transactional()` takes an optional argument that is the same as the `option` argument to `Database.tx()` in `pg-promise` ([docs](https://vitaly-t.github.io/pg-promise/Database.html#tx)).
+
 ## Example
 
 ```ts title="user.service.ts"

--- a/packages/transactional-adapters/transactional-adapter-pg-promise/src/lib/transactional-adapter-pg-promise.ts
+++ b/packages/transactional-adapters/transactional-adapter-pg-promise/src/lib/transactional-adapter-pg-promise.ts
@@ -10,6 +10,8 @@ export interface PgPromiseTransactionalAdapterOptions {
      * The injection token for the pg-promise instance.
      */
     dbInstanceToken: any;
+
+    defaultTxOptions?: TxOptions;
 }
 
 export class TransactionalAdapterPgPromise
@@ -17,8 +19,11 @@ export class TransactionalAdapterPgPromise
 {
     connectionToken: any;
 
+    defaultTxOptions?: TxOptions;
+
     constructor(options: PgPromiseTransactionalAdapterOptions) {
         this.connectionToken = options.dbInstanceToken;
+        this.defaultTxOptions = options.defaultTxOptions;
     }
 
     optionsFactory = (pgPromiseDbInstance: Database) => ({
@@ -27,10 +32,13 @@ export class TransactionalAdapterPgPromise
             fn: (...args: any[]) => Promise<any>,
             setClient: (client?: Database) => void,
         ) => {
-            return pgPromiseDbInstance.tx(options ?? {}, (tx) => {
-                setClient(tx as unknown as Database);
-                return fn();
-            });
+            return pgPromiseDbInstance.tx(
+                options ?? this.defaultTxOptions ?? {},
+                (tx) => {
+                    setClient(tx as unknown as Database);
+                    return fn();
+                },
+            );
         },
         getFallbackInstance: () => pgPromiseDbInstance,
     });

--- a/packages/transactional-adapters/transactional-adapter-pg-promise/src/lib/transactional-adapter-pg-promise.ts
+++ b/packages/transactional-adapters/transactional-adapter-pg-promise/src/lib/transactional-adapter-pg-promise.ts
@@ -11,6 +11,10 @@ export interface PgPromiseTransactionalAdapterOptions {
      */
     dbInstanceToken: any;
 
+    /**
+     * Default options for the transaction. These will be merged with any transaction-specific options
+     * passed to the `@Transactional` decorator or the `TransactionHost#withTransaction` method.
+     */
     defaultTxOptions?: TxOptions;
 }
 
@@ -33,7 +37,7 @@ export class TransactionalAdapterPgPromise
             setClient: (client?: Database) => void,
         ) => {
             return pgPromiseDbInstance.tx(
-                options ?? this.defaultTxOptions ?? {},
+                { ...this.defaultTxOptions, ...options },
                 (tx) => {
                     setClient(tx as unknown as Database);
                     return fn();

--- a/packages/transactional-adapters/transactional-adapter-pg-promise/test/transactional-adapter-pg-promise.spec.ts
+++ b/packages/transactional-adapters/transactional-adapter-pg-promise/test/transactional-adapter-pg-promise.spec.ts
@@ -219,64 +219,8 @@ describe('TransactionalAdapterPgPromise', () => {
 
     beforeEach(() => jest.resetAllMocks());
 
-    describe('optionsFactory()', () => {
-        test('no default options, no tx options', async () => {
-            const transactionalAdapterPgPromise =
-                new TransactionalAdapterPgPromise({
-                    dbInstanceToken: 'SOME_TOKEN',
-                });
-            const { wrapWithTransaction } =
-                transactionalAdapterPgPromise.optionsFactory({
-                    tx: txMock,
-                } as unknown as Database);
-
-            await wrapWithTransaction(null, jest.fn(), jest.fn());
-
-            expect(txMock).toHaveBeenCalledTimes(1);
-            expect(txMock).toHaveBeenCalledWith({}, expect.anything());
-        });
-
-        test('default options only', async () => {
-            const defaultTxOptions = { tag: 'some-tag' };
-
-            const transactionalAdapterPgPromise =
-                new TransactionalAdapterPgPromise({
-                    dbInstanceToken: 'SOME_TOKEN',
-                    defaultTxOptions,
-                });
-            const { wrapWithTransaction } =
-                transactionalAdapterPgPromise.optionsFactory({
-                    tx: txMock,
-                } as unknown as Database);
-
-            await wrapWithTransaction(null, jest.fn(), jest.fn());
-
-            expect(txMock).toHaveBeenCalledTimes(1);
-            expect(txMock).toHaveBeenCalledWith(
-                defaultTxOptions,
-                expect.anything(),
-            );
-        });
-
-        test('tx options only', async () => {
-            const txOptions = { tag: 'some-tag' };
-
-            const transactionalAdapterPgPromise =
-                new TransactionalAdapterPgPromise({
-                    dbInstanceToken: 'SOME_TOKEN',
-                });
-            const { wrapWithTransaction } =
-                transactionalAdapterPgPromise.optionsFactory({
-                    tx: txMock,
-                } as unknown as Database);
-
-            await wrapWithTransaction(txOptions, jest.fn(), jest.fn());
-
-            expect(txMock).toHaveBeenCalledTimes(1);
-            expect(txMock).toHaveBeenCalledWith(txOptions, expect.anything());
-        });
-
-        test('default options and tx options', async () => {
+    describe('wrapWithTransaction()', () => {
+        describe('sets the transaction options correctly', () => {
             const defaultTxOptions = { tag: 'some-tag' };
             const txOptions = {
                 mode: new txMode.TransactionMode({
@@ -284,23 +228,80 @@ describe('TransactionalAdapterPgPromise', () => {
                 }),
             };
 
-            const transactionalAdapterPgPromise =
-                new TransactionalAdapterPgPromise({
-                    dbInstanceToken: 'SOME_TOKEN',
+            test('no default options, no tx options', async () => {
+                const transactionalAdapterPgPromise =
+                    new TransactionalAdapterPgPromise({
+                        dbInstanceToken: 'SOME_TOKEN',
+                    });
+                const { wrapWithTransaction } =
+                    transactionalAdapterPgPromise.optionsFactory({
+                        tx: txMock,
+                    } as unknown as Database);
+
+                await wrapWithTransaction(null, jest.fn(), jest.fn());
+
+                expect(txMock).toHaveBeenCalledTimes(1);
+                expect(txMock).toHaveBeenCalledWith({}, expect.anything());
+            });
+
+            test('default options only', async () => {
+                const transactionalAdapterPgPromise =
+                    new TransactionalAdapterPgPromise({
+                        dbInstanceToken: 'SOME_TOKEN',
+                        defaultTxOptions,
+                    });
+                const { wrapWithTransaction } =
+                    transactionalAdapterPgPromise.optionsFactory({
+                        tx: txMock,
+                    } as unknown as Database);
+
+                await wrapWithTransaction(null, jest.fn(), jest.fn());
+
+                expect(txMock).toHaveBeenCalledTimes(1);
+                expect(txMock).toHaveBeenCalledWith(
                     defaultTxOptions,
-                });
-            const { wrapWithTransaction } =
-                transactionalAdapterPgPromise.optionsFactory({
-                    tx: txMock,
-                } as unknown as Database);
+                    expect.anything(),
+                );
+            });
 
-            await wrapWithTransaction(txOptions, jest.fn(), jest.fn());
+            test('tx options only', async () => {
+                const transactionalAdapterPgPromise =
+                    new TransactionalAdapterPgPromise({
+                        dbInstanceToken: 'SOME_TOKEN',
+                    });
+                const { wrapWithTransaction } =
+                    transactionalAdapterPgPromise.optionsFactory({
+                        tx: txMock,
+                    } as unknown as Database);
 
-            expect(txMock).toHaveBeenCalledTimes(1);
-            expect(txMock).toHaveBeenCalledWith(
-                { tag: 'some-tag', mode: txOptions.mode },
-                expect.anything(),
-            );
+                await wrapWithTransaction(txOptions, jest.fn(), jest.fn());
+
+                expect(txMock).toHaveBeenCalledTimes(1);
+                expect(txMock).toHaveBeenCalledWith(
+                    txOptions,
+                    expect.anything(),
+                );
+            });
+
+            test('default options and tx options', async () => {
+                const transactionalAdapterPgPromise =
+                    new TransactionalAdapterPgPromise({
+                        dbInstanceToken: 'SOME_TOKEN',
+                        defaultTxOptions,
+                    });
+                const { wrapWithTransaction } =
+                    transactionalAdapterPgPromise.optionsFactory({
+                        tx: txMock,
+                    } as unknown as Database);
+
+                await wrapWithTransaction(txOptions, jest.fn(), jest.fn());
+
+                expect(txMock).toHaveBeenCalledTimes(1);
+                expect(txMock).toHaveBeenCalledWith(
+                    { tag: 'some-tag', mode: txOptions.mode },
+                    expect.anything(),
+                );
+            });
         });
     });
 });

--- a/packages/transactional-adapters/transactional-adapter-pg-promise/test/transactional-adapter-pg-promise.spec.ts
+++ b/packages/transactional-adapters/transactional-adapter-pg-promise/test/transactional-adapter-pg-promise.spec.ts
@@ -212,14 +212,11 @@ describe('Transactional', () => {
             );
         });
     });
-});
-
-describe('TransactionalAdapterPgPromise', () => {
-    const txMock = jest.fn();
-
-    beforeEach(() => jest.resetAllMocks());
-
     describe('wrapWithTransaction()', () => {
+        const txMock = jest.fn();
+
+        beforeEach(() => jest.resetAllMocks());
+
         describe('sets the transaction options correctly', () => {
             const defaultTxOptions = { tag: 'some-tag' };
             const txOptions = {


### PR DESCRIPTION
This PR adds the ability to specify default options for the `@Transactional` decorator, so that they don't need to be specified repeatedly.