### PR TITLE
feat(transactional): add default options parameter to transactional adapter 

### DIFF
--- a/packages/transactional-adapters/transactional-adapter-knex/src/lib/transactional-adapter-knex.ts
+++ b/packages/transactional-adapters/transactional-adapter-knex/src/lib/transactional-adapter-knex.ts
@@ -6,6 +6,12 @@ export interface KnexTransactionalAdapterOptions {
      * The injection token for the Knex instance.
      */
     knexInstanceToken: any;
+
+    /**
+     * Default options for the transaction. These will be merged with any transaction-specific options
+     * passed to the `@Transactional` decorator or the `TransactionHost#withTransaction` method.
+     */
+    defaultTxOptions?: Partial<Knex.TransactionConfig>;
 }
 
 export class TransactionalAdapterKnex
@@ -13,8 +19,11 @@ export class TransactionalAdapterKnex
 {
     connectionToken: any;
 
+    defaultTxOptions?: Partial<Knex.TransactionConfig>;
+
     constructor(options: KnexTransactionalAdapterOptions) {
         this.connectionToken = options.knexInstanceToken;
+        this.defaultTxOptions = options.defaultTxOptions;
     }
 
     optionsFactory = (knexInstance: Knex) => ({

--- a/packages/transactional-adapters/transactional-adapter-knex/test/transactional-adapter-knex.spec.ts
+++ b/packages/transactional-adapters/transactional-adapter-knex/test/transactional-adapter-knex.spec.ts
@@ -7,8 +7,8 @@ import {
 } from '@nestjs-cls/transactional';
 import { Inject, Injectable, Module } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { ClsModule } from 'nestjs-cls';
 import Knex from 'knex';
+import { ClsModule } from 'nestjs-cls';
 import { TransactionalAdapterKnex } from '../src';
 
 const KNEX = 'KNEX';
@@ -179,6 +179,21 @@ describe('Transactional', () => {
             expect(users).toEqual(
                 expect.not.arrayContaining([{ name: 'Nobody' }]),
             );
+        });
+    });
+});
+
+describe('Default options', () => {
+    it('Should correctly set default options on the adapter instance', async () => {
+        const adapter = new TransactionalAdapterKnex({
+            knexInstanceToken: KNEX,
+            defaultTxOptions: {
+                isolationLevel: 'snapshot',
+            },
+        });
+
+        expect(adapter.defaultTxOptions).toEqual({
+            isolationLevel: 'snapshot',
         });
     });
 });

--- a/packages/transactional-adapters/transactional-adapter-kysely/src/lib/transactional-adapter-kysely.ts
+++ b/packages/transactional-adapters/transactional-adapter-kysely/src/lib/transactional-adapter-kysely.ts
@@ -6,6 +6,12 @@ export interface KyselyTransactionalAdapterOptions {
      * The injection token for the Kysely instance.
      */
     kyselyInstanceToken: any;
+
+    /**
+     * Default options for the transaction. These will be merged with any transaction-specific options
+     * passed to the `@Transactional` decorator or the `TransactionHost#withTransaction` method.
+     */
+    defaultTxOptions?: Partial<KyselyTransactionOptions>;
 }
 
 export interface KyselyTransactionOptions {
@@ -15,12 +21,16 @@ export interface KyselyTransactionOptions {
 }
 
 export class TransactionalAdapterKysely<DB = any>
-    implements TransactionalAdapter<Kysely<DB>, Kysely<DB>, any>
+    implements
+        TransactionalAdapter<Kysely<DB>, Kysely<DB>, KyselyTransactionOptions>
 {
     connectionToken: any;
 
+    defaultTxOptions?: Partial<KyselyTransactionOptions>;
+
     constructor(options: KyselyTransactionalAdapterOptions) {
         this.connectionToken = options.kyselyInstanceToken;
+        this.defaultTxOptions = options.defaultTxOptions;
     }
 
     optionsFactory = (kyselyDb: Kysely<DB>) => ({

--- a/packages/transactional-adapters/transactional-adapter-kysely/test/transactional-adapter-kysely.spec.ts
+++ b/packages/transactional-adapters/transactional-adapter-kysely/test/transactional-adapter-kysely.spec.ts
@@ -233,3 +233,18 @@ describe('Transactional', () => {
         });
     });
 });
+
+describe('Default options', () => {
+    it('Should correctly set default options on the adapter instance', async () => {
+        const adapter = new TransactionalAdapterKysely({
+            kyselyInstanceToken: KYSELY,
+            defaultTxOptions: {
+                isolationLevel: 'repeatable read',
+            },
+        });
+
+        expect(adapter.defaultTxOptions).toEqual({
+            isolationLevel: 'repeatable read',
+        });
+    });
+});

--- a/packages/transactional-adapters/transactional-adapter-pg-promise/test/transactional-adapter-pg-promise.spec.ts
+++ b/packages/transactional-adapters/transactional-adapter-pg-promise/test/transactional-adapter-pg-promise.spec.ts
@@ -213,3 +213,18 @@ describe('Transactional', () => {
         });
     });
 });
+
+describe('Default options', () => {
+    it('Should correctly set default options on the adapter instance', async () => {
+        const adapter = new TransactionalAdapterPgPromise({
+            dbInstanceToken: PG_PROMISE,
+            defaultTxOptions: {
+                tag: 'test-tag',
+            },
+        });
+
+        expect(adapter.defaultTxOptions).toEqual({
+            tag: 'test-tag',
+        });
+    });
+});

--- a/packages/transactional-adapters/transactional-adapter-pg-promise/test/transactional-adapter-pg-promise.spec.ts
+++ b/packages/transactional-adapters/transactional-adapter-pg-promise/test/transactional-adapter-pg-promise.spec.ts
@@ -9,7 +9,7 @@ import { Inject, Injectable, Module } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ClsModule } from 'nestjs-cls';
 import { execSync } from 'node:child_process';
-import pgPromise, { txMode } from 'pg-promise';
+import pgPromise from 'pg-promise';
 import { Database, TransactionalAdapterPgPromise } from '../src';
 
 type UserRecord = { id: number; name: string; email: string };
@@ -210,95 +210,6 @@ describe('Transactional', () => {
             expect(users).toEqual(
                 expect.not.arrayContaining([{ name: 'Nobody' }]),
             );
-        });
-    });
-    describe('wrapWithTransaction()', () => {
-        const txMock = jest.fn();
-
-        beforeEach(() => jest.resetAllMocks());
-
-        describe('sets the transaction options correctly', () => {
-            const defaultTxOptions = { tag: 'some-tag' };
-            const txOptions = {
-                mode: new txMode.TransactionMode({
-                    tiLevel: txMode.isolationLevel.serializable,
-                }),
-            };
-
-            test('no default options, no tx options', async () => {
-                const transactionalAdapterPgPromise =
-                    new TransactionalAdapterPgPromise({
-                        dbInstanceToken: 'SOME_TOKEN',
-                    });
-                const { wrapWithTransaction } =
-                    transactionalAdapterPgPromise.optionsFactory({
-                        tx: txMock,
-                    } as unknown as Database);
-
-                await wrapWithTransaction(null, jest.fn(), jest.fn());
-
-                expect(txMock).toHaveBeenCalledTimes(1);
-                expect(txMock).toHaveBeenCalledWith({}, expect.anything());
-            });
-
-            test('default options only', async () => {
-                const transactionalAdapterPgPromise =
-                    new TransactionalAdapterPgPromise({
-                        dbInstanceToken: 'SOME_TOKEN',
-                        defaultTxOptions,
-                    });
-                const { wrapWithTransaction } =
-                    transactionalAdapterPgPromise.optionsFactory({
-                        tx: txMock,
-                    } as unknown as Database);
-
-                await wrapWithTransaction(null, jest.fn(), jest.fn());
-
-                expect(txMock).toHaveBeenCalledTimes(1);
-                expect(txMock).toHaveBeenCalledWith(
-                    defaultTxOptions,
-                    expect.anything(),
-                );
-            });
-
-            test('tx options only', async () => {
-                const transactionalAdapterPgPromise =
-                    new TransactionalAdapterPgPromise({
-                        dbInstanceToken: 'SOME_TOKEN',
-                    });
-                const { wrapWithTransaction } =
-                    transactionalAdapterPgPromise.optionsFactory({
-                        tx: txMock,
-                    } as unknown as Database);
-
-                await wrapWithTransaction(txOptions, jest.fn(), jest.fn());
-
-                expect(txMock).toHaveBeenCalledTimes(1);
-                expect(txMock).toHaveBeenCalledWith(
-                    txOptions,
-                    expect.anything(),
-                );
-            });
-
-            test('default options and tx options', async () => {
-                const transactionalAdapterPgPromise =
-                    new TransactionalAdapterPgPromise({
-                        dbInstanceToken: 'SOME_TOKEN',
-                        defaultTxOptions,
-                    });
-                const { wrapWithTransaction } =
-                    transactionalAdapterPgPromise.optionsFactory({
-                        tx: txMock,
-                    } as unknown as Database);
-
-                await wrapWithTransaction(txOptions, jest.fn(), jest.fn());
-
-                expect(txMock).toHaveBeenCalledTimes(1);
-                expect(txMock).toHaveBeenCalledWith(
-                    { tag: 'some-tag', mode: txOptions.mode },
-                    expect.anything(),
-                );
-            });
         });
     });
 });

--- a/packages/transactional-adapters/transactional-adapter-prisma/src/lib/transactional-adapter-prisma.ts
+++ b/packages/transactional-adapters/transactional-adapter-prisma/src/lib/transactional-adapter-prisma.ts
@@ -13,11 +13,19 @@ export type PrismaTransactionOptions<
     TClient extends AnyTransactionClient = PrismaClient,
 > = Parameters<TClient['$transaction']>[1];
 
-export interface PrismaTransactionalAdapterOptions {
+export interface PrismaTransactionalAdapterOptions<
+    TClient extends AnyTransactionClient = PrismaClient,
+> {
     /**
      * The injection token for the PrismaClient instance.
      */
     prismaInjectionToken: any;
+
+    /**
+     * Default options for the transaction. These will be merged with any transaction-specific options
+     * passed to the `@Transactional` decorator or the `TransactionHost#withTransaction` method.
+     */
+    defaultTxOptions?: Partial<PrismaTransactionOptions<TClient>>;
 }
 
 export class TransactionalAdapterPrisma<
@@ -31,8 +39,11 @@ export class TransactionalAdapterPrisma<
 {
     connectionToken: any;
 
-    constructor(options: { prismaInjectionToken: any }) {
+    defaultTxOptions?: Partial<PrismaTransactionOptions<TClient>>;
+
+    constructor(options: PrismaTransactionalAdapterOptions<TClient>) {
         this.connectionToken = options.prismaInjectionToken;
+        this.defaultTxOptions = options.defaultTxOptions;
     }
 
     optionsFactory = (prisma: TClient) => ({

--- a/packages/transactional-adapters/transactional-adapter-prisma/test/transactional-adapter-prisma-custom-client.spec.ts
+++ b/packages/transactional-adapters/transactional-adapter-prisma/test/transactional-adapter-prisma-custom-client.spec.ts
@@ -67,9 +67,11 @@ class PrismaModule {}
             plugins: [
                 new ClsPluginTransactional({
                     imports: [PrismaModule],
-                    adapter: new TransactionalAdapterPrisma({
-                        prismaInjectionToken: CUSTOM_PRISMA_CLIENT,
-                    }),
+                    adapter: new TransactionalAdapterPrisma<CustomPrismaClient>(
+                        {
+                            prismaInjectionToken: CUSTOM_PRISMA_CLIENT,
+                        },
+                    ),
                     enableTransactionProxy: true,
                 }),
             ],

--- a/packages/transactional-adapters/transactional-adapter-prisma/test/transactional-adapter-prisma.spec.ts
+++ b/packages/transactional-adapters/transactional-adapter-prisma/test/transactional-adapter-prisma.spec.ts
@@ -161,3 +161,18 @@ describe('Transactional', () => {
         });
     });
 });
+
+describe('Default options', () => {
+    it('Should correctly set default options on the adapter instance', async () => {
+        const adapter = new TransactionalAdapterPrisma({
+            prismaInjectionToken: PrismaClient,
+            defaultTxOptions: {
+                timeout: 24,
+            },
+        });
+
+        expect(adapter.defaultTxOptions).toEqual({
+            timeout: 24,
+        });
+    });
+});

--- a/packages/transactional-adapters/transactional-adapter-typeorm/src/lib/transactional-adapter-typeorm.ts
+++ b/packages/transactional-adapters/transactional-adapter-typeorm/src/lib/transactional-adapter-typeorm.ts
@@ -7,6 +7,12 @@ export interface TypeOrmTransactionalAdapterOptions {
      * The injection token for the TypeORM DataSource instance.
      */
     dataSourceToken: any;
+
+    /**
+     * Default options for the transaction. These will be merged with any transaction-specific options
+     * passed to the `@Transactional` decorator or the `TransactionHost#withTransaction` method.
+     */
+    defaultTxOptions?: Partial<TypeOrmTransactionOptions>;
 }
 
 export interface TypeOrmTransactionOptions {
@@ -23,8 +29,11 @@ export class TransactionalAdapterTypeOrm
 {
     connectionToken: any;
 
+    defaultTxOptions?: Partial<TypeOrmTransactionOptions>;
+
     constructor(options: TypeOrmTransactionalAdapterOptions) {
         this.connectionToken = options.dataSourceToken;
+        this.defaultTxOptions = options.defaultTxOptions;
     }
 
     optionsFactory = (dataSource: DataSource) => ({

--- a/packages/transactional-adapters/transactional-adapter-typeorm/test/transactional-adapter-typeorm.spec.ts
+++ b/packages/transactional-adapters/transactional-adapter-typeorm/test/transactional-adapter-typeorm.spec.ts
@@ -9,7 +9,7 @@ import { Injectable, Module } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ClsModule } from 'nestjs-cls';
 import { execSync } from 'node:child_process';
-import { DataSource, Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Column, DataSource, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import { TransactionalAdapterTypeOrm } from '../src';
 
 @Entity()
@@ -205,6 +205,21 @@ describe('Transactional', () => {
             expect(users).toEqual(
                 expect.not.arrayContaining([{ name: 'Nobody' }]),
             );
+        });
+    });
+});
+
+describe('Default options', () => {
+    it('Should correctly set default options on the adapter instance', async () => {
+        const adapter = new TransactionalAdapterTypeOrm({
+            dataSourceToken: DataSource,
+            defaultTxOptions: {
+                isolationLevel: 'READ COMMITTED',
+            },
+        });
+
+        expect(adapter.defaultTxOptions).toEqual({
+            isolationLevel: 'READ COMMITTED',
         });
     });
 });

--- a/packages/transactional/src/lib/interfaces.ts
+++ b/packages/transactional/src/lib/interfaces.ts
@@ -11,6 +11,7 @@ export interface MergedTransactionalAdapterOptions<TTx, TOptions>
     extends TransactionalAdapterOptions<TTx, TOptions> {
     connectionName: string | undefined;
     enableTransactionProxy: boolean;
+    defaultTxOptions: Partial<TOptions>;
 }
 
 export type TransactionalOptionsAdapterFactory<TConnection, TTx, TOptions> = (
@@ -23,6 +24,11 @@ export interface TransactionalAdapter<TConnection, TTx, TOptions> {
      * It is later used to create transactions.
      */
     connectionToken: any;
+
+    /**
+     * Default options for all transactions
+     */
+    defaultTxOptions?: Partial<TOptions>;
 
     /**
      * Function that accepts the `connection` based on the `connectionToken`

--- a/packages/transactional/src/lib/plugin-transactional.ts
+++ b/packages/transactional/src/lib/plugin-transactional.ts
@@ -43,6 +43,8 @@ export class ClsPluginTransactional implements ClsPlugin {
                         connectionName: options.connectionName,
                         enableTransactionProxy:
                             options.enableTransactionProxy ?? false,
+                        defaultTxOptions:
+                            options.adapter.defaultTxOptions ?? {},
                     };
                 },
             },

--- a/packages/transactional/src/lib/transaction-host.ts
+++ b/packages/transactional/src/lib/transaction-host.ts
@@ -131,6 +131,7 @@ export class TransactionHost<TAdapter = never> {
             fn = firstParam;
         }
         propagation ??= Propagation.Required;
+        options = { ...this._options.defaultTxOptions, ...options };
         return this.decidePropagationAndRun(propagation, options, fn);
     }
 

--- a/packages/transactional/test/default-options.spec.ts
+++ b/packages/transactional/test/default-options.spec.ts
@@ -1,0 +1,152 @@
+import { Injectable, Module } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClsModule } from 'nestjs-cls';
+import { ClsPluginTransactional, Transactional, TransactionHost } from '../src';
+import {
+    MockDbConnection,
+    TransactionAdapterMock,
+} from './transaction-adapter-mock';
+
+@Injectable()
+class CalledService {
+    constructor(
+        private readonly txHost: TransactionHost<TransactionAdapterMock>,
+    ) {}
+
+    async doWork(num: number) {
+        return this.txHost.tx.query(`SELECT ${num}`);
+    }
+}
+
+@Injectable()
+class CallingService {
+    constructor(
+        private readonly calledService: CalledService,
+        private readonly txHost: TransactionHost<TransactionAdapterMock>,
+    ) {}
+
+    @Transactional<TransactionAdapterMock>({
+        serializable: true,
+    })
+    async transactionalDecoratorWithDefaultOptions() {
+        return await this.calledService.doWork(1);
+    }
+
+    @Transactional<TransactionAdapterMock>({
+        serializable: true,
+        sayHello: false,
+    })
+    async transactionalDecoratorWithCustomOptions() {
+        return await this.calledService.doWork(2);
+    }
+
+    async withTransactionWithDefaultOptions() {
+        return await this.txHost.withTransaction(
+            { serializable: true },
+            async () => this.calledService.doWork(3),
+        );
+    }
+
+    async withTransactionWithCustomOptions() {
+        return await this.txHost.withTransaction(
+            { serializable: true, sayHello: false },
+            async () => this.calledService.doWork(4),
+        );
+    }
+}
+
+@Module({
+    providers: [MockDbConnection],
+    exports: [MockDbConnection],
+})
+class DbConnectionModule {}
+
+@Module({
+    imports: [
+        ClsModule.forRoot({
+            plugins: [
+                new ClsPluginTransactional({
+                    imports: [DbConnectionModule],
+                    adapter: new TransactionAdapterMock({
+                        connectionToken: MockDbConnection,
+                        defaultTxOptions: { sayHello: true },
+                    }),
+                }),
+            ],
+        }),
+    ],
+    providers: [CallingService, CalledService],
+})
+class AppModule {}
+
+describe('Using defaultOptions in Transactional adapter', () => {
+    let module: TestingModule;
+    let callingService: CallingService;
+    let mockDbConnection: MockDbConnection;
+    beforeEach(async () => {
+        module = await Test.createTestingModule({
+            imports: [AppModule],
+        }).compile();
+        await module.init();
+        callingService = module.get(CallingService);
+        mockDbConnection = module.get(MockDbConnection);
+    });
+
+    describe('when using the @Transactional decorator', () => {
+        it('should merge passed options with default ones', async () => {
+            const result =
+                await callingService.transactionalDecoratorWithDefaultOptions();
+            expect(result).toEqual({ query: 'SELECT 1' });
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([
+                [
+                    '/* Hello */ SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; BEGIN TRANSACTION;',
+                    'SELECT 1',
+                    'COMMIT TRANSACTION;',
+                ],
+            ]);
+        });
+        it('should override default options with explicit one', async () => {
+            const result =
+                await callingService.transactionalDecoratorWithCustomOptions();
+            expect(result).toEqual({ query: 'SELECT 2' });
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([
+                [
+                    'SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; BEGIN TRANSACTION;',
+                    'SELECT 2',
+                    'COMMIT TRANSACTION;',
+                ],
+            ]);
+        });
+    });
+
+    describe('when using the withTransaction method', () => {
+        it('should merge passed options with default ones', async () => {
+            const result =
+                await callingService.withTransactionWithDefaultOptions();
+            expect(result).toEqual({ query: 'SELECT 3' });
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([
+                [
+                    '/* Hello */ SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; BEGIN TRANSACTION;',
+                    'SELECT 3',
+                    'COMMIT TRANSACTION;',
+                ],
+            ]);
+        });
+        it('should override default options with explicit one', async () => {
+            const result =
+                await callingService.withTransactionWithCustomOptions();
+            expect(result).toEqual({ query: 'SELECT 4' });
+            const queries = mockDbConnection.getClientsQueries();
+            expect(queries).toEqual([
+                [
+                    'SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; BEGIN TRANSACTION;',
+                    'SELECT 4',
+                    'COMMIT TRANSACTION;',
+                ],
+            ]);
+        });
+    });
+});

--- a/packages/transactional/test/multiple-connections.spec.ts
+++ b/packages/transactional/test/multiple-connections.spec.ts
@@ -128,7 +128,7 @@ class DbConnectionModule2 {}
 })
 class AppModule {}
 
-describe('Transactional', () => {
+describe('Transactional - multiple connections', () => {
     let module: TestingModule;
     let callingService: CallingService;
     let mockDbConnection1: MockDbConnection;

--- a/packages/transactional/test/named-connection.spec.ts
+++ b/packages/transactional/test/named-connection.spec.ts
@@ -113,7 +113,7 @@ class DbConnectionModule {}
 })
 class AppModule {}
 
-describe('Transactional', () => {
+describe('Transactional - named connections', () => {
     let module: TestingModule;
     let callingService: CallingService;
     let mockDbConnection: MockDbConnection;

--- a/packages/transactional/test/transaction-adapter-mock.ts
+++ b/packages/transactional/test/transaction-adapter-mock.ts
@@ -30,6 +30,7 @@ export class MockDbConnection {
 
 export interface MockTransactionOptions {
     serializable?: boolean;
+    sayHello?: boolean;
 }
 
 export class TransactionAdapterMock
@@ -41,9 +42,16 @@ export class TransactionAdapterMock
         >
 {
     connectionToken: any;
-    constructor(options: { connectionToken: any }) {
+    defaultTxOptions: Partial<MockTransactionOptions>;
+
+    constructor(options: {
+        connectionToken: any;
+        defaultTxOptions?: MockTransactionOptions;
+    }) {
         this.connectionToken = options.connectionToken;
+        this.defaultTxOptions = options.defaultTxOptions ?? {};
     }
+
     optionsFactory = (connection: MockDbConnection) => ({
         wrapWithTransaction: async (
             options: MockTransactionOptions | undefined,
@@ -57,6 +65,9 @@ export class TransactionAdapterMock
                 beginQuery =
                     'SET TRANSACTION ISOLATION LEVEL SERIALIZABLE; ' +
                     beginQuery;
+            }
+            if (options?.sayHello) {
+                beginQuery = '/* Hello */ ' + beginQuery;
             }
             await client.query(beginQuery);
             try {


### PR DESCRIPTION
Enables setting default options for all transactions started with `@nestjs-cls/transactional`