### PR TITLE
feat(transactional): adds supports propagation mode

### DIFF
--- a/docs/docs/06_plugins/01_available-plugins/01-transactional/index.md
+++ b/docs/docs/06_plugins/01_available-plugins/01-transactional/index.md
@@ -301,6 +301,9 @@ The propagation option is controlled by the `Propagation` enum, which has the fo
 -   **_`Never`_**:
     Run without a transaction, throw an exception if one already exists.
 
+-   **_`Supports`_**:
+    Reuse the existing transaction or continue without a transaction if none exists.
+
 This parameter comes _before_ the `TransactionOptions` object, if one is provided. The default behavior when a nested transaction decorator is encountered if no propagation option is provided, is to reuse the existing transaction or create a new one if none exists, which is the same as the `Required` propagation option.
 
 Example:

--- a/packages/transactional/src/lib/propagation.ts
+++ b/packages/transactional/src/lib/propagation.ts
@@ -22,6 +22,10 @@ export enum Propagation {
      * Run without a transaction, throw an exception if one already exists.
      */
     Never = 'NEVER',
+    /**
+     * Reuse the existing transaction or continue without a transaction if none exists.
+     */
+    Supports = 'SUPPORTS',
 }
 
 /**

--- a/packages/transactional/src/lib/transaction-host.ts
+++ b/packages/transactional/src/lib/transaction-host.ts
@@ -177,6 +177,16 @@ export class TransactionHost<TAdapter = never> {
                     throw new TransactionAlreadyActiveError(fnName);
                 }
                 return this.withoutTransaction(fn);
+            case Propagation.Supports:
+                if (this.isTransactionActive()) {
+                    if (isNotEmpty(options)) {
+                        this.logger.warn(
+                            `Transaction options are ignored because the propagation mode is ${propagation} (for method ${fnName}).`,
+                        );
+                    }
+                    return fn();
+                }
+                return this.withoutTransaction(fn);
             default:
                 throw new TransactionPropagationError(
                     `Unknown propagation mode ${propagation}`,


### PR DESCRIPTION
Adds the "SUPPORTS" propagation mode (inspired by Spring "SUPPORTS" transaction propagation behavior).