### PR TITLE
fix(core): update fastify route pattern to support latest syntax

### DIFF
--- a/packages/core/src/lib/cls.module.ts
+++ b/packages/core/src/lib/cls.module.ts
@@ -72,7 +72,7 @@ export class ClsModule implements NestModule {
         const adapter = this.adapterHost.httpAdapter;
         let mountPoint = '/';
         if (adapter.constructor.name === 'FastifyAdapter') {
-            mountPoint = '(.*)';
+            mountPoint = '{*path}';
         }
 
         if (options.mount) {


### PR DESCRIPTION
## Description
When using NestJS 11 with `setGlobalPrefix('api')`, the following warning appears:
```
WARN [LegacyRouteConverter] Unsupported route path: "/api/(.*)". In previous versions, the symbols ?, *, and + were used to denote optional or repeating path parameters. The latest version of "path-to-regexp" now requires the use of named parameters. For example, instead of using a route like /users/* to capture all routes starting with "/users", you should use /users/*path. For more details, refer to the migration guide. Attempting to auto-convert...
```

This warning occurs because `ClsModule` uses the legacy route pattern `(.*)` for FastifyAdapter, which is no longer supported by newer versions of `path-to-regexp` used in Express>=v5 and `@fastify/middie>=v9`.

Looking at the [NestJS core code](https://github.com/nestjs/nest/blob/master/packages/core/router/legacy-route-converter.ts#L10), we can see that this change is required for compatibility with `@fastify/middie`, which is a dependency of `@nestjs/platform-fastify`.

## Changes
This PR updates the route pattern in `ClsModule` from:
```typescript
if (adapter.constructor.name === 'FastifyAdapter') {
    mountPoint = '(.*)';
}
```
to:
```typescript
if (adapter.constructor.name === 'FastifyAdapter') {
    mountPoint = '{*path}';
}
```

## Why
1. Support for unnamed wildcards is deprecated in newer versions of `path-to-regexp`
2. This change ensures compatibility with Express>=v5 and `@fastify/middie>=v9`
3. Removes warning messages when using NestJS 11 with global prefixes
4. Aligns with the new standardized route pattern syntax

## Testing
- [x] Tested with NestJS 11
- [x] Tested with global prefix
- [x] Verified that warning no longer appears
- [x] Confirmed that CLS functionality works as expected

## Related Issues
- NestJS 11 compatibility
- Express 5 and `@fastify/middie` v9 route pattern requirements