### PR TITLE
fix(core): reuse context when other Cls-enhancers are used together with ClsMiddleware with Fastify 5

### DIFF
--- a/packages/core/src/lib/cls-initializers/utils/context-cls-store-map.ts
+++ b/packages/core/src/lib/cls-initializers/utils/context-cls-store-map.ts
@@ -36,7 +36,12 @@ export class ContextClsStoreMap {
     private static getContextByType(context: ExecutionContext): any {
         switch (context.getType() as ContextType | 'graphql') {
             case 'http':
-                return context.switchToHttp().getRequest();
+                const request = context.switchToHttp().getRequest();
+                // Workaround for Fastify
+                // When setting the request from ClsMiddleware, we only have access to the "raw" request
+                // But when accessing it from other enhancers, we receive the "full" request. Therefore,
+                // we have to reach into the "raw" property to be able to compare the identity of the request.
+                return request.raw ?? request;
             case 'ws':
                 return context.switchToWs();
             case 'rpc':

--- a/packages/core/test/common/test.middleware.ts
+++ b/packages/core/test/common/test.middleware.ts
@@ -1,0 +1,12 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { ClsService } from '../../src';
+
+@Injectable()
+export class TestMiddleware implements NestMiddleware {
+    constructor(private readonly cls: ClsService) {}
+
+    use(_req: any, _res: any, next: (error?: any) => void) {
+        this.cls.set('FROM_MIDDLEWARE', this.cls.getId());
+        return next();
+    }
+}

--- a/packages/core/test/rest/expect-ids-rest.ts
+++ b/packages/core/test/rest/expect-ids-rest.ts
@@ -2,14 +2,19 @@ import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 
 export const expectOkIdsRest =
-    (path = '/hello') =>
+    (path = '/hello', expectedId?: string) =>
     (app: INestApplication) =>
         request(app.getHttpServer())
             .get(path)
             .expect(200)
             .then((r) => {
                 const body = r.body;
-                const id = body.fromGuard ?? body.fromInterceptor;
+                // try to get the first possible id
+                const id =
+                    expectedId ??
+                    body.fromMiddleware ??
+                    body.fromGuard ??
+                    body.fromInterceptor;
                 expect(body.fromInterceptor).toEqual(id);
                 expect(body.fromInterceptorAfter).toEqual(id);
                 expect(body.fromController).toEqual(id);
@@ -24,7 +29,11 @@ export const expectErrorIdsRest =
             .expect(500)
             .then((r) => {
                 const body = r.body;
-                const id = body.fromGuard ?? body.fromInterceptor;
+                // try to get the first possible id
+                const id =
+                    body.fromMiddleware ??
+                    body.fromGuard ??
+                    body.fromInterceptor;
                 expect(body.fromInterceptor).toEqual(id);
                 expect(body.fromController).toEqual(id);
                 expect(body.fromService).toEqual(id);

--- a/packages/core/test/rest/http.app.ts
+++ b/packages/core/test/rest/http.app.ts
@@ -18,6 +18,7 @@ export class TestHttpService {
 
     async hello() {
         return {
+            fromMiddleware: this.cls.get('FROM_MIDDLEWARE'),
             fromGuard: this.cls.get('FROM_GUARD'),
             fromInterceptor: this.cls.get('FROM_INTERCEPTOR'),
             fromInterceptorAfter: this.cls.get('FROM_INTERCEPTOR'),


### PR DESCRIPTION
Fixes #222 