### PR TITLE
build: Include source maps in packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,8 @@
   "types": "dist/src/index.d.ts",
   "files": [
     "dist/src/**/!(*.spec).d.ts",
-    "dist/src/**/!(*.spec).js"
+    "dist/src/**/!(*.spec).js",
+    "dist/src/**/!(*.spec).js.map"
   ],
   "scripts": {
     "prepack": "cp ../../LICENSE ./LICENSE && cp ../../README.md ./README.md && yarn build",

--- a/packages/transactional-adapters/transactional-adapter-drizzle-orm/package.json
+++ b/packages/transactional-adapters/transactional-adapter-drizzle-orm/package.json
@@ -36,7 +36,8 @@
     "types": "dist/src/index.d.ts",
     "files": [
         "dist/src/**/!(*.spec).d.ts",
-        "dist/src/**/!(*.spec).js"
+        "dist/src/**/!(*.spec).js",
+        "dist/src/**/!(*.spec).js.map"
     ],
     "scripts": {
         "prepack": "cp ../../../LICENSE ./LICENSE",

--- a/packages/transactional-adapters/transactional-adapter-knex/package.json
+++ b/packages/transactional-adapters/transactional-adapter-knex/package.json
@@ -35,7 +35,8 @@
     "types": "dist/src/index.d.ts",
     "files": [
         "dist/src/**/!(*.spec).d.ts",
-        "dist/src/**/!(*.spec).js"
+        "dist/src/**/!(*.spec).js",
+        "dist/src/**/!(*.spec).js.amp"
     ],
     "scripts": {
         "prepack": "cp ../../../LICENSE ./LICENSE",

--- a/packages/transactional-adapters/transactional-adapter-kysely/package.json
+++ b/packages/transactional-adapters/transactional-adapter-kysely/package.json
@@ -35,7 +35,8 @@
     "types": "dist/src/index.d.ts",
     "files": [
         "dist/src/**/!(*.spec).d.ts",
-        "dist/src/**/!(*.spec).js"
+        "dist/src/**/!(*.spec).js",
+        "dist/src/**/!(*.spec).js.map"
     ],
     "scripts": {
         "prepack": "cp ../../../LICENSE ./LICENSE",

--- a/packages/transactional-adapters/transactional-adapter-mongodb/package.json
+++ b/packages/transactional-adapters/transactional-adapter-mongodb/package.json
@@ -35,7 +35,8 @@
     "types": "dist/src/index.d.ts",
     "files": [
         "dist/src/**/!(*.spec).d.ts",
-        "dist/src/**/!(*.spec).js"
+        "dist/src/**/!(*.spec).js",
+        "dist/src/**/!(*.spec).js.map"
     ],
     "scripts": {
         "prepack": "cp ../../../LICENSE ./LICENSE",

--- a/packages/transactional-adapters/transactional-adapter-mongoose/package.json
+++ b/packages/transactional-adapters/transactional-adapter-mongoose/package.json
@@ -35,7 +35,8 @@
     "types": "dist/src/index.d.ts",
     "files": [
         "dist/src/**/!(*.spec).d.ts",
-        "dist/src/**/!(*.spec).js"
+        "dist/src/**/!(*.spec).js",
+        "dist/src/**/!(*.spec).js.map"
     ],
     "scripts": {
         "prepack": "cp ../../../LICENSE ./LICENSE",

--- a/packages/transactional-adapters/transactional-adapter-pg-promise/package.json
+++ b/packages/transactional-adapters/transactional-adapter-pg-promise/package.json
@@ -30,7 +30,8 @@
     "types": "dist/src/index.d.ts",
     "files": [
         "dist/src/**/!(*.spec).d.ts",
-        "dist/src/**/!(*.spec).js"
+        "dist/src/**/!(*.spec).js",
+        "dist/src/**/!(*.spec).js.map"
     ],
     "scripts": {
         "prepack": "cp ../../../LICENSE ./LICENSE",

--- a/packages/transactional-adapters/transactional-adapter-prisma/package.json
+++ b/packages/transactional-adapters/transactional-adapter-prisma/package.json
@@ -35,7 +35,8 @@
   "types": "dist/src/index.d.ts",
   "files": [
     "dist/src/**/!(*.spec).d.ts",
-    "dist/src/**/!(*.spec).js"
+    "dist/src/**/!(*.spec).js",
+    "dist/src/**/!(*.spec).js.map"
   ],
   "scripts": {
     "prepack": "cp ../../../LICENSE ./LICENSE",

--- a/packages/transactional-adapters/transactional-adapter-typeorm/package.json
+++ b/packages/transactional-adapters/transactional-adapter-typeorm/package.json
@@ -31,7 +31,8 @@
     "types": "dist/src/index.d.ts",
     "files": [
         "dist/src/**/!(*.spec).d.ts",
-        "dist/src/**/!(*.spec).js"
+        "dist/src/**/!(*.spec).js",
+        "dist/src/**/!(*.spec).js.map"
     ],
     "scripts": {
         "prepack": "cp ../../../LICENSE ./LICENSE",

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -34,7 +34,8 @@
   "types": "dist/src/index.d.ts",
   "files": [
     "dist/src/**/!(*.spec).d.ts",
-    "dist/src/**/!(*.spec).js"
+    "dist/src/**/!(*.spec).js",
+    "dist/src/**/!(*.spec).js.map"
   ],
   "scripts": {
     "prepack": "cp ../../LICENSE ./LICENSE",


### PR DESCRIPTION
Source maps are enabled in tsconfig.json, but not included in the packages.

This leads to invalid `//#sourceMappingURL` lines generated in the files which broke my bundler

I've attempted to add the source maps to the packages.

I did not know which conventional commit type to use for this commit, but I will change if it necessary.

An alternative approach would be to just disable `sourceMaps` in `tsconfig.json`
