### PR TITLE
Fix isolation level not percolating through to transaction execution

### DIFF
--- a/packages/transactional-adapters/transactional-adapter-kysely/src/lib/transactional-adapter-kysely.ts
+++ b/packages/transactional-adapters/transactional-adapter-kysely/src/lib/transactional-adapter-kysely.ts
@@ -39,9 +39,9 @@ export class TransactionalAdapterKysely<DB = any>
             fn: (...args: any[]) => Promise<any>,
             setClient: (client?: Kysely<DB>) => void,
         ) => {
-            const transaction = kyselyDb.transaction();
+            let transaction = kyselyDb.transaction();
             if (options?.isolationLevel) {
-                transaction.setIsolationLevel(options.isolationLevel);
+                transaction = transaction.setIsolationLevel(options.isolationLevel);
             }
             return transaction.execute(async (trx) => {
                 setClient(trx);

--- a/packages/transactional-adapters/transactional-adapter-kysely/test/transactional-adapter-kysely.spec.ts
+++ b/packages/transactional-adapters/transactional-adapter-kysely/test/transactional-adapter-kysely.spec.ts
@@ -265,7 +265,7 @@ describe('Transactional', () => {
                     })
                     .returningAll()
                     .executeTakeFirstOrThrow();
-                console.log(`userA: ${userA.id}`);
+
                 userB = await kyselyDb
                     .insertInto('user')
                     .values({


### PR DESCRIPTION
Hello folks 👋 

For the past few hours I've been trying to produce, on purpose, a PostgreSQL "[serialization anomaly](https://www.postgresql.org/docs/current/transaction-iso.html)" in my test harness in order to retrieve the proper error code or message from the pg lib, so as to be able to retry said transaction on the client side.

I got worried I didn't succeed in having my transactions aborted so I took a look inside the kysely adapter to see.

Long story short, I stumbled upon a very small but tremendously dangerous bug inside `TransactionalAdapterKysely`, right here: https://github.com/Papooch/nestjs-cls/blob/9b304c4464a227c52870708130b81473086e0b01/packages/transactional-adapters/transactional-adapter-kysely/src/lib/transactional-adapter-kysely.ts#L42-L46

Indeed, the `Kysely<DB>$transaction` function returns an immutable-like builder pattern object, so its `transaction.setIsolationLevel` method actually returns a new builder instead of modifying the current one.

Consequently, the `transaction.execute` is completely oblivious to the isolation level change that was supposed to happen and kysely does not pass the proper settings to its call to `driver.beginTransaction`...

I've added a failing test case in a first commit and a fix in a second one.

Hope this helps and looking forward to a new release. Cheers.