### PR TITLE
feat(transactional-adapter-kysely) support kysely access mode

### DIFF
--- a/packages/transactional-adapters/transactional-adapter-kysely/package.json
+++ b/packages/transactional-adapters/transactional-adapter-kysely/package.json
@@ -47,7 +47,7 @@
     },
     "peerDependencies": {
         "@nestjs-cls/transactional": "workspace:^2.7.0",
-        "kysely": "^0.27",
+        "kysely": "^0.28",
         "nestjs-cls": "workspace:^5.4.3"
     },
     "devDependencies": {
@@ -60,7 +60,7 @@
         "@types/node": "^22.15.12",
         "@types/pg": "^8.11.14",
         "jest": "^29.7.0",
-        "kysely": "^0.28.0",
+        "kysely": "^0.28.2",
         "pg": "^8.15.6",
         "reflect-metadata": "^0.2.2",
         "rimraf": "^6.0.1",

--- a/packages/transactional-adapters/transactional-adapter-kysely/src/lib/transactional-adapter-kysely.ts
+++ b/packages/transactional-adapters/transactional-adapter-kysely/src/lib/transactional-adapter-kysely.ts
@@ -18,6 +18,9 @@ export interface KyselyTransactionOptions {
     isolationLevel?: Parameters<
         TransactionBuilder<any>['setIsolationLevel']
     >[0];
+    accessMode?: Parameters<
+        TransactionBuilder<any>['setAccessMode']
+    >[0];
 }
 
 export class TransactionalAdapterKysely<DB = any>
@@ -42,6 +45,9 @@ export class TransactionalAdapterKysely<DB = any>
             let transaction = kyselyDb.transaction();
             if (options?.isolationLevel) {
                 transaction = transaction.setIsolationLevel(options.isolationLevel);
+            }
+            if (options?.accessMode) {
+                transaction = transaction.setAccessMode(options.accessMode);
             }
             return transaction.execute(async (trx) => {
                 setClient(trx);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6533,7 +6533,7 @@ __metadata:
     "@types/node": "npm:^22.15.12"
     "@types/pg": "npm:^8.11.14"
     jest: "npm:^29.7.0"
-    kysely: "npm:^0.28.0"
+    kysely: "npm:^0.28.2"
     pg: "npm:^8.15.6"
     reflect-metadata: "npm:^0.2.2"
     rimraf: "npm:^6.0.1"
@@ -6545,7 +6545,7 @@ __metadata:
     typescript: "npm:5.8.3"
   peerDependencies:
     "@nestjs-cls/transactional": "workspace:^2.7.0"
-    kysely: ^0.27
+    kysely: ^0.28
     nestjs-cls: "workspace:^5.4.3"
   languageName: unknown
   linkType: soft
@@ -17179,10 +17179,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kysely@npm:^0.28.0":
-  version: 0.28.0
-  resolution: "kysely@npm:0.28.0"
-  checksum: 10c0/7b4be048c0c2d1850c9c3f12bf6f9f7691addaddbc430d8b4e56a12fe36f52153bb1b12d5b54dff4f72eb8a53cbae95a7fab2a84f22b804e2154cb68bf509358
+"kysely@npm:^0.28.2":
+  version: 0.28.2
+  resolution: "kysely@npm:0.28.2"
+  checksum: 10c0/66eccd19e6476a10f3b004835c4a966516968003075aa0c217db48ecd0f9679a2efa812f797063540cdb4e3e81fbf5afe876e1f7a08a1550e1fd99acc2a6dbb9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Kysely has support for transaction access modes now ([0.28.0](https://github.com/kysely-org/kysely/releases/tag/0.28.0)) so I've ported it here.

Might be a good idea to bump to 0.28.2 as well to benefit from the latest bug fixes.

Cheers 🙂 