### PR TITLE
fix(core): do not publish source maps

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "dist/src/**/!(*.spec).js"
   ],
   "scripts": {
-    "prepack": "cp ../../LICENSE ./LICENSE && cp ../../README.md ./README.md && yarn build",
+    "prepack": "cp ../../LICENSE ./LICENSE && cp ../../README.md ./README.md",
     "prebuild": "rimraf dist",
     "build": "tsc",
     "test": "NODE_OPTIONS=\"${NODE_OPTIONS:-} --experimental-vm-modules\" jest",


### PR DESCRIPTION
Fixes #239 

Previously, a `build:release` script was added to the root package json in https://github.com/Papooch/nestjs-cls/pull/306 that should address the issue, but a rogue `&& yarn build` was still left in the `prepublish` script of the core package, which would add the source maps back.

This PR removes that unnecessary  build step from the core package (all other packages have already been published without source maps)