### PR TITLE
feat(transactional): support nested transaction propagation

### DIFF
--- a/docs/docs/06_plugins/01_available-plugins/01-transactional/01-prisma-adapter.md
+++ b/docs/docs/06_plugins/01_available-plugins/01-transactional/01-prisma-adapter.md
@@ -42,6 +42,8 @@ ClsModule.forRoot({
             adapter: new TransactionalAdapterPrisma({
                 // the injection token of the PrismaClient
                 prismaInjectionToken: PrismaService,
+                // specify the SQL flavor (if using SQL, see below)
+                sqlFlavor: 'postgresql'
             }),
         }),
     ],
@@ -51,6 +53,16 @@ ClsModule.forRoot({
 :::important
 
 The `prismaInjectionToken` is the token under which an instance of [`PrismaClient`](https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/introduction) provided. Usually, in Nest, this the custom `PrismaService` class which `extends PrismaClient` and is exported from a custom module.
+
+:::
+
+:::note
+
+The `sqlFlavor` option is needed to enable nested transaction support via [`Propagation.Nested`](../01-transactional/index.md#transaction-propagation).
+
+Since [Prisma _does not_ yet support nested transactions natively](https://github.com/prisma/prisma/issues/15212), the adapter implements a custom solution via raw queries and SQL _SAVEPOINTS_. But because different SQL flavors implement the syntax differently, and because Prisma also _does not provide a way to introspect the datasource provider name at runtime_, we need to specify it manually.
+
+Please note that if the datasource in your Prisma schema and the SQL flavor do not match, syntax errors might be thrown when attempting to use nested transactions.
 
 :::
 

--- a/docs/docs/06_plugins/01_available-plugins/01-transactional/06-mongodb-adapter.md
+++ b/docs/docs/06_plugins/01_available-plugins/01-transactional/06-mongodb-adapter.md
@@ -62,7 +62,13 @@ Queries are not executed using the `ClientSession` instance, but instead the `Cl
 
 The `TransactionalAdapterMongoDB` _does not support_ the ["Transaction Proxy"](./index.md#using-the-injecttransaction-decorator) feature, because proxying an `undefined` value is not supported by the JavaScript Proxy.
 
-::::
+:::
+
+:::note
+
+MongoDB does not support savepoints or nested transactions. Using `Propagation.Nested` will re-use the existing transaction.
+
+:::
 
 ## Example
 

--- a/docs/docs/06_plugins/01_available-plugins/01-transactional/07-mongoose-adapter.md
+++ b/docs/docs/06_plugins/01_available-plugins/01-transactional/07-mongoose-adapter.md
@@ -62,7 +62,13 @@ Queries are not executed using the `ClientSession` instance, but instead the `Cl
 
 The `TransactionalAdapterMongoose` _does not support_ the ["Transaction Proxy"](./index.md#using-the-injecttransaction-decorator) feature, because proxying a `null` value is not supported by the JavaScript Proxy.
 
-::::
+:::
+
+:::note
+
+MongoDB does not support savepoints or nested transactions. Using `Propagation.Nested` will re-use the existing transaction.
+
+:::
 
 ## Example
 

--- a/docs/docs/06_plugins/01_available-plugins/01-transactional/index.md
+++ b/docs/docs/06_plugins/01_available-plugins/01-transactional/index.md
@@ -305,9 +305,9 @@ The propagation option is controlled by the `Propagation` enum, which has the fo
 
 - **_`Supports`_**:
   Reuse the existing transaction or continue without a transaction if none exists.
-- 
+
 - **_`Nested`_**:
-  Create a subtransaction if supported; otherwise, reuse the existing transaction or create a new one if none exists.
+  Create a subtransaction if supported; otherwise, reuse the existing transaction or create a new one if none exists. (See specific adapter docs on nested transactions support)
 
 This parameter comes _before_ the `TransactionOptions` object, if one is provided. The default behavior when a nested transaction decorator is encountered if no propagation option is provided, is to reuse the existing transaction or create a new one if none exists, which is the same as the `Required` propagation option.
 

--- a/docs/docs/06_plugins/01_available-plugins/01-transactional/index.md
+++ b/docs/docs/06_plugins/01_available-plugins/01-transactional/index.md
@@ -305,6 +305,9 @@ The propagation option is controlled by the `Propagation` enum, which has the fo
 
 - **_`Supports`_**:
   Reuse the existing transaction or continue without a transaction if none exists.
+- 
+- **_`Nested`_**:
+  Create a subtransaction if supported; otherwise, reuse the existing transaction or create a new one if none exists.
 
 This parameter comes _before_ the `TransactionOptions` object, if one is provided. The default behavior when a nested transaction decorator is encountered if no propagation option is provided, is to reuse the existing transaction or create a new one if none exists, which is the same as the `Required` propagation option.
 

--- a/packages/transactional-adapters/transactional-adapter-drizzle-orm/src/lib/transactional-adapter-drizzle-orm.ts
+++ b/packages/transactional-adapters/transactional-adapter-drizzle-orm/src/lib/transactional-adapter-drizzle-orm.ts
@@ -54,6 +54,17 @@ export class TransactionalAdapterDrizzleOrm<TClient extends AnyDrizzleClient>
                 return fn();
             }, options);
         },
+        wrapWithNestedTransaction: async (
+            options: DrizzleTransactionOptions<TClient>,
+            fn: (...args: any[]) => Promise<any>,
+            setClient: (client?: TClient) => void,
+            client: TClient,
+        ) => {
+            return client.transaction(async (tx) => {
+                setClient(tx as TClient);
+                return fn();
+            }, options);
+        },
         getFallbackInstance: () => drizzleInstance,
     });
 }

--- a/packages/transactional-adapters/transactional-adapter-knex/src/lib/transactional-adapter-knex.ts
+++ b/packages/transactional-adapters/transactional-adapter-knex/src/lib/transactional-adapter-knex.ts
@@ -37,6 +37,17 @@ export class TransactionalAdapterKnex
                 return fn();
             }, options);
         },
+        wrapWithNestedTransaction: (
+            options: Knex.TransactionConfig,
+            fn: (...args: any[]) => Promise<any>,
+            setClient: (client?: Knex) => void,
+            client: Knex,
+        ) => {
+            return client.transaction(async (trx) => {
+                setClient(trx);
+                return fn();
+            }, options);
+        },
         getFallbackInstance: () => knexInstance,
     });
 }

--- a/packages/transactional-adapters/transactional-adapter-knex/test/transactional-adapter-knex.spec.ts
+++ b/packages/transactional-adapters/transactional-adapter-knex/test/transactional-adapter-knex.spec.ts
@@ -1,6 +1,7 @@
 import {
     ClsPluginTransactional,
     InjectTransaction,
+    Propagation,
     Transaction,
     Transactional,
     TransactionHost,
@@ -85,6 +86,25 @@ class UserService {
     async transactionWithDecoratorError() {
         await this.userRepository.createUser('Nobody');
         throw new Error('Rollback');
+    }
+
+    @Transactional()
+    async transactionalHasNested(name?: string) {
+        await this.nestedTransaction(name);
+        try {
+            await this.nestedTransactionError(name);
+        } catch (_: any) {}
+    }
+
+    @Transactional(Propagation.Nested)
+    async nestedTransaction(name = 'Anybody') {
+        await this.userRepository.createUser(name);
+    }
+
+    @Transactional(Propagation.Nested)
+    async nestedTransactionError(name = 'Anybody') {
+        await this.userRepository.createUser(name);
+        throw new Error();
     }
 }
 
@@ -192,6 +212,15 @@ describe('Transactional', () => {
             expect(users).toEqual(
                 expect.not.arrayContaining([{ name: 'Nobody' }]),
             );
+        });
+
+        it('should work with in nested tx', async () => {
+            await callingService.transactionalHasNested('Anybody2');
+
+            const users = await knex('user').where({ name: 'Anybody2' });
+
+            // partial rollback
+            expect(users).toHaveLength(1);
         });
     });
 });

--- a/packages/transactional-adapters/transactional-adapter-kysely/src/lib/transactional-adapter-kysely.ts
+++ b/packages/transactional-adapters/transactional-adapter-kysely/src/lib/transactional-adapter-kysely.ts
@@ -1,5 +1,6 @@
 import { TransactionalAdapter } from '@nestjs-cls/transactional';
-import { Kysely, TransactionBuilder } from 'kysely';
+import { ControlledTransaction, Kysely, TransactionBuilder } from 'kysely';
+import { randomUUID } from 'crypto';
 
 export interface KyselyTransactionalAdapterOptions {
     /**
@@ -40,20 +41,93 @@ export class TransactionalAdapterKysely<DB = any>
             fn: (...args: any[]) => Promise<any>,
             setClient: (client?: Kysely<DB>) => void,
         ) => {
-            let transaction = kyselyDb.transaction();
-            if (options?.isolationLevel) {
-                transaction = transaction.setIsolationLevel(
-                    options.isolationLevel,
-                );
-            }
-            if (options?.accessMode) {
-                transaction = transaction.setAccessMode(options.accessMode);
-            }
-            return transaction.execute(async (trx) => {
+            const trx = await txBuilder(kyselyDb, options);
+            try {
                 setClient(trx);
-                return fn();
-            });
+
+                const result = await fn();
+
+                await trx.commit().execute();
+
+                return result;
+            } catch (e) {
+                await trx.rollback().execute();
+                throw e;
+            }
+        },
+        wrapWithNestedTransaction: async (
+            options: KyselyTransactionOptions,
+            fn: (...args: any[]) => Promise<any>,
+            setClient: (client?: Kysely<DB>) => void,
+            client: Kysely<DB>,
+        ) => {
+            const savepointTx = await SavepointTransaction.initialize(client);
+
+            try {
+                setClient(savepointTx.client);
+
+                return await savepointTx.runInSavePoint(fn);
+            } catch (e) {
+                await savepointTx.rollback();
+
+                throw e;
+            }
         },
         getFallbackInstance: () => kyselyDb,
     });
+}
+
+const generateSavePointId = () =>
+    `savepoint_${randomUUID().replace(/-/g, '_')}`;
+
+const txBuilder = async <DB>(
+    client: Kysely<DB>,
+    options: KyselyTransactionOptions,
+) => {
+    let transaction = client.startTransaction();
+
+    if (options?.isolationLevel) {
+        transaction = transaction.setIsolationLevel(options.isolationLevel);
+    }
+
+    if (options?.accessMode) {
+        transaction = transaction.setAccessMode(options.accessMode);
+    }
+
+    return transaction.execute();
+};
+
+class SavepointTransaction<DB> {
+    private constructor(
+        public readonly client: ControlledTransaction<DB, string[]>,
+        private readonly savepointId: string,
+    ) {}
+
+    static async initialize<DB>(
+        client: Kysely<DB>,
+        savepointId: string = generateSavePointId(),
+    ) {
+        const trx = await (client as ControlledTransaction<DB, string[]>)
+            .savepoint(savepointId)
+            .execute();
+
+        return new SavepointTransaction(trx, savepointId);
+    }
+
+    async runInSavePoint(fn: (...args: any[]) => Promise<any>) {
+        const result = await fn();
+
+        await this.client.releaseSavepoint(this.savepointId).execute();
+
+        return result;
+    }
+
+    async rollback() {
+        try {
+            await this.client.rollbackToSavepoint(this.savepointId).execute();
+        } catch (e) {
+            // Maybe it is needed to operate something for driver which does not support save point
+            throw e;
+        }
+    }
 }

--- a/packages/transactional-adapters/transactional-adapter-pg-promise/src/lib/transactional-adapter-pg-promise.ts
+++ b/packages/transactional-adapters/transactional-adapter-pg-promise/src/lib/transactional-adapter-pg-promise.ts
@@ -41,6 +41,17 @@ export class TransactionalAdapterPgPromise
                 return fn();
             });
         },
+        wrapWithNestedTransaction: async (
+            options: PgPromiseTxOptions,
+            fn: (...args: any[]) => Promise<any>,
+            setClient: (client?: Database) => void,
+            client: Database,
+        ) => {
+            return client.tx(options, (tx) => {
+                setClient(tx as unknown as Database);
+                return fn();
+            });
+        },
         getFallbackInstance: () => pgPromiseDbInstance,
     });
 }

--- a/packages/transactional-adapters/transactional-adapter-pg-promise/test/transactional-adapter-pg-promise.spec.ts
+++ b/packages/transactional-adapters/transactional-adapter-pg-promise/test/transactional-adapter-pg-promise.spec.ts
@@ -1,6 +1,7 @@
 import {
     ClsPluginTransactional,
     InjectTransaction,
+    Propagation,
     Transaction,
     Transactional,
     TransactionHost,
@@ -105,6 +106,25 @@ class UserService {
     async transactionWithDecoratorError() {
         await this.userRepository.createUser('Nobody');
         throw new Error('Rollback');
+    }
+
+    @Transactional()
+    async transactionalHasNested(name?: string) {
+        await this.nestedTransaction(name);
+    }
+
+    @Transactional(Propagation.Nested)
+    async nestedTransaction(name = 'Anybody') {
+        await this.userRepository.createUser(name);
+        try {
+            await this.nestedTransactionError(name);
+        } catch (_: any) {}
+    }
+
+    @Transactional(Propagation.Nested)
+    async nestedTransactionError(name = 'Anybody') {
+        await this.userRepository.createUser(name);
+        throw new Error();
     }
 }
 
@@ -225,6 +245,17 @@ describe('Transactional', () => {
             expect(users).toEqual(
                 expect.not.arrayContaining([{ name: 'Nobody' }]),
             );
+        });
+        it('should work with nested transaction', async () => {
+            await callingService.transactionalHasNested('Anybody');
+
+            const users = await db.many(
+                'SELECT * FROM public.user WHERE name = $1',
+                'Anybody',
+            );
+
+            // partial rollback
+            expect(users).toHaveLength(1);
         });
     });
 });

--- a/packages/transactional-adapters/transactional-adapter-prisma/prisma/migrations/20240119144105_init/migration.sql
+++ b/packages/transactional-adapters/transactional-adapter-prisma/prisma/migrations/20240119144105_init/migration.sql
@@ -4,6 +4,3 @@ CREATE TABLE "User" (
     "email" TEXT NOT NULL,
     "name" TEXT
 );
-
--- CreateIndex
-CREATE UNIQUE INDEX "User_email_key" ON "User"("email");

--- a/packages/transactional-adapters/transactional-adapter-prisma/prisma/schema.prisma
+++ b/packages/transactional-adapters/transactional-adapter-prisma/prisma/schema.prisma
@@ -12,6 +12,6 @@ datasource db {
 
 model User {
   id    Int     @id @default(autoincrement())
-  email String  @unique
+  email String
   name  String?
 }

--- a/packages/transactional-adapters/transactional-adapter-prisma/src/lib/savepoint-syntax.ts
+++ b/packages/transactional-adapters/transactional-adapter-prisma/src/lib/savepoint-syntax.ts
@@ -1,0 +1,72 @@
+export type SQLFlavor =
+    | 'postgresql'
+    | 'mysql'
+    | 'sqlite'
+    | 'mssql'
+    | 'azuresql'
+    | 'mariadb'
+    | 'oracle';
+
+type SavepointStatementGetter = (savepointId: string) => string;
+type SavepointStatementGetters = {
+    save: SavepointStatementGetter;
+    release: (savepointId: string) => string | null;
+    rollback: SavepointStatementGetter;
+};
+type SavepointStatements = {
+    save: string;
+    release: string | null;
+    rollback: string;
+};
+
+const standardSyntax: SavepointStatementGetters = {
+    save: (id) => `SAVEPOINT ${id};`,
+    release: (id) => `RELEASE SAVEPOINT ${id};`,
+    rollback: (id) => `ROLLBACK TO SAVEPOINT ${id};`,
+};
+
+const microsoftSyntax: SavepointStatementGetters = {
+    save: (id) => `SAVE TRANSACTION ${id};`,
+    release: () => null,
+    rollback: (id) => `ROLLBACK TRANSACTION ${id};`,
+};
+
+const oracleSyntax: SavepointStatementGetters = {
+    save: (id) => `SAVEPOINT ${id};`,
+    release: () => null,
+    rollback: (id) => `ROLLBACK TO SAVEPOINT ${id};`,
+};
+
+const savepointStatementGetters = new Map<SQLFlavor, SavepointStatementGetters>(
+    [
+        ['postgresql', standardSyntax],
+        ['mysql', standardSyntax],
+        ['mariadb', standardSyntax],
+        ['sqlite', standardSyntax],
+        ['mssql', microsoftSyntax],
+        ['azuresql', microsoftSyntax],
+        ['oracle', oracleSyntax],
+    ],
+);
+
+export function getSavepointStatements(
+    flavor: SQLFlavor,
+    id: string,
+): SavepointStatements {
+    const statements = savepointStatementGetters.get(flavor);
+    if (!statements) {
+        throw new InvalidSQLFlavorError(flavor);
+    }
+    return {
+        save: statements.save(id),
+        release: statements.release(id),
+        rollback: statements.rollback(id),
+    };
+}
+
+export class InvalidSQLFlavorError extends Error {
+    constructor(flavor: string) {
+        super(`Invalid SQL flavor: ${flavor}`);
+        this.name = 'InvalidSQLFlavorError';
+    }
+}

--- a/packages/transactional-adapters/transactional-adapter-prisma/src/lib/transactional-adapter-prisma.ts
+++ b/packages/transactional-adapters/transactional-adapter-prisma/src/lib/transactional-adapter-prisma.ts
@@ -1,7 +1,7 @@
 import { TransactionalAdapter } from '@nestjs-cls/transactional';
 import { PrismaClient } from '@prisma/client';
-import { randomUUID } from 'crypto';
 import { getSavepointStatements, SQLFlavor } from './savepoint-syntax';
+import { randomUUID } from 'crypto';
 
 interface AnyTransactionClient {
     $transaction: (fn: (client: any) => Promise<any>, options?: any) => any;
@@ -85,7 +85,7 @@ export class TransactionalAdapterPrisma<
         tx: any, // use `any` to please TypeScript (or figure out a better type)
     ) => {
         const client = tx as PrismaClient;
-        const savepointId = `savepoint_${randomUUID().replace(/-/g, '_')}`;
+        const savepointId = generateSavePointId();
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const statements = getSavepointStatements(this.sqlFlavor!, savepointId);
         setClient(client);
@@ -102,3 +102,6 @@ export class TransactionalAdapterPrisma<
         }
     };
 }
+
+const generateSavePointId = () =>
+    `savepoint_${randomUUID().replace(/-/g, '_')}`;

--- a/packages/transactional-adapters/transactional-adapter-prisma/src/lib/transactional-adapter-prisma.ts
+++ b/packages/transactional-adapters/transactional-adapter-prisma/src/lib/transactional-adapter-prisma.ts
@@ -1,5 +1,7 @@
 import { TransactionalAdapter } from '@nestjs-cls/transactional';
 import { PrismaClient } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import { getSavepointStatements, SQLFlavor } from './savepoint-syntax';
 
 interface AnyTransactionClient {
     $transaction: (fn: (client: any) => Promise<any>, options?: any) => any;
@@ -26,6 +28,16 @@ export interface PrismaTransactionalAdapterOptions<
      * passed to the `@Transactional` decorator or the `TransactionHost#withTransaction` method.
      */
     defaultTxOptions?: Partial<PrismaTransactionOptions<TClient>>;
+
+    /**
+     * Specify the SQL flavor used by the database (does not apply to NoSQL databases).
+     *
+     * This is used to determine the syntax for savepoints in nested transactions, because
+     * the PrismaClient does not provide a way to determine the SQL flavor automatically.
+     *
+     * If not provided, the adapter will not support nested transactions.
+     */
+    sqlFlavor?: SQLFlavor;
 }
 
 export class TransactionalAdapterPrisma<
@@ -41,9 +53,12 @@ export class TransactionalAdapterPrisma<
 
     defaultTxOptions?: Partial<PrismaTransactionOptions<TClient>>;
 
+    sqlFlavor?: SQLFlavor;
+
     constructor(options: PrismaTransactionalAdapterOptions<TClient>) {
         this.connectionToken = options.prismaInjectionToken;
         this.defaultTxOptions = options.defaultTxOptions;
+        this.sqlFlavor = options.sqlFlavor;
     }
 
     optionsFactory = (prisma: TClient) => ({
@@ -57,6 +72,33 @@ export class TransactionalAdapterPrisma<
                 return fn();
             }, options);
         },
+        wrapWithNestedTransaction: this.sqlFlavor
+            ? this.wrapWithNestedTransaction
+            : undefined,
         getFallbackInstance: () => prisma,
     });
+
+    private readonly wrapWithNestedTransaction = async (
+        _options: PrismaTransactionOptions,
+        fn: (...args: any[]) => Promise<any>,
+        setClient: (client?: PrismaTransactionalClient<TClient>) => void,
+        tx: any, // use `any` to please TypeScript (or figure out a better type)
+    ) => {
+        const client = tx as PrismaClient;
+        const savepointId = `savepoint_${randomUUID().replace(/-/g, '_')}`;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const statements = getSavepointStatements(this.sqlFlavor!, savepointId);
+        setClient(client);
+        try {
+            await client.$executeRawUnsafe(statements.save);
+
+            const result = await fn();
+            statements.release &&
+                (await client.$executeRawUnsafe(statements.release));
+            return result;
+        } catch (e) {
+            await client.$executeRawUnsafe(statements.rollback);
+            throw e;
+        }
+    };
 }

--- a/packages/transactional-adapters/transactional-adapter-typeorm/src/lib/transactional-adapter-typeorm.ts
+++ b/packages/transactional-adapters/transactional-adapter-typeorm/src/lib/transactional-adapter-typeorm.ts
@@ -47,6 +47,18 @@ export class TransactionalAdapterTypeOrm
                 return fn();
             });
         },
+        wrapWithNestedTransaction: async (
+            options: TypeOrmTransactionOptions,
+            fn: (...args: any[]) => Promise<any>,
+
+            setClient: (client?: EntityManager) => void,
+            client: EntityManager,
+        ) => {
+            return client.transaction(options?.isolationLevel, (trx) => {
+                setClient(trx);
+                return fn();
+            });
+        },
         getFallbackInstance: () => dataSource.manager,
     });
 }

--- a/packages/transactional/src/lib/interfaces.ts
+++ b/packages/transactional/src/lib/interfaces.ts
@@ -12,6 +12,12 @@ export interface TransactionalAdapterOptions<TTx, TOptions> {
         fn: (...args: any[]) => Promise<any>,
         setTx: (client?: TTx) => void,
     ) => Promise<any>;
+    wrapWithNestedTransaction?: (
+        options: TOptions,
+        fn: (...args: any[]) => Promise<any>,
+        setTx: (client?: TTx) => void,
+        tx: TTx,
+    ) => Promise<any>;
     getFallbackInstance: () => TTx;
 }
 

--- a/packages/transactional/src/lib/propagation.ts
+++ b/packages/transactional/src/lib/propagation.ts
@@ -6,6 +6,7 @@ export enum Propagation {
      * (default) Reuse the existing transaction or create a new one if none exists.
      */
     Required = 'REQUIRED',
+
     /**
      * Create a new transaction even if one already exists. The new transaction is committed independently of the existing one.
      */
@@ -26,6 +27,11 @@ export enum Propagation {
      * Reuse the existing transaction or continue without a transaction if none exists.
      */
     Supports = 'SUPPORTS',
+
+    /**
+     * Create a subtransaction if supported; otherwise, reuse the existing transaction or create a new one if none exists.
+     */
+    Nested = 'NESTED',
 }
 
 /**

--- a/packages/transactional/src/lib/transaction-host.ts
+++ b/packages/transactional/src/lib/transaction-host.ts
@@ -248,7 +248,7 @@ export class TransactionHost<TAdapter = never> {
                         this.setTxInstance.bind(this),
                         this.tx,
                     )
-                    .finally(() => this.setTxInstance(undefined));
+                    .finally(() => this.setTxInstance(this.tx));
             }
             this.logger.warn(
                 `Nested Propagation option is ignored because an adapter does not support nested transactions (for method ${fn.name}).`,

--- a/packages/transactional/test/transaction-adapter-mock.ts
+++ b/packages/transactional/test/transaction-adapter-mock.ts
@@ -96,6 +96,23 @@ export class TransactionAdapterMock
                 throw e;
             }
         },
+        wrapWithNestedTransaction: async (
+            _options: MockTransactionOptions | undefined,
+            fn: (...args: any[]) => Promise<any>,
+            setTxInstance: (client?: MockDbClient) => void,
+            tx: MockDbClient,
+        ) => {
+            setTxInstance(tx);
+            try {
+                await tx.query('SAVEPOINT nested_transaction;');
+                const result = await fn();
+                await tx.query('RELEASE SAVEPOINT nested_transaction;');
+                return result;
+            } catch (e) {
+                await tx.query('ROLLBACK TO SAVEPOINT nested_transaction;');
+                throw e;
+            }
+        },
         getFallbackInstance: () => {
             return connection.getClient();
         },


### PR DESCRIPTION
This branch should be merged once the support for `Propagation.Nested` is implemented for all existing transactional adapters (that support it)

Prior work on the transactional host has been done by @gring2, as well as the implementation for the TypeORM adapter.

To add add nested transactions support for other adapters, please create a branch from this one, and also target the PR here.

---

The PR will be ready to merge once support for the following adapters is added:

- [x] Prisma
- [x] Knex
- [x] Kysely
- [x] Pg-promise
- [x] TypeORM
- [x] Drizzle ORM