### PR TITLE
feat: add nested propagation to adpaters

### DIFF
--- a/docs/docs/06_plugins/01_available-plugins/01-transactional/index.md
+++ b/docs/docs/06_plugins/01_available-plugins/01-transactional/index.md
@@ -307,7 +307,7 @@ The propagation option is controlled by the `Propagation` enum, which has the fo
   Reuse the existing transaction or continue without a transaction if none exists.
 - 
 - **_`Nested`_**:
-  Create a subtransaction if supported; otherwise, reuse the existing transaction or create a new one if none exists.
+  Create a subtransaction (postgresql savepoint) if supported (currently only typeorm, drizzle-orm, knex and pg-promise); otherwise, reuse the existing transaction or create a new one if none exists.
 
 This parameter comes _before_ the `TransactionOptions` object, if one is provided. The default behavior when a nested transaction decorator is encountered if no propagation option is provided, is to reuse the existing transaction or create a new one if none exists, which is the same as the `Required` propagation option.
 

--- a/packages/transactional-adapters/transactional-adapter-drizzle-orm/src/lib/transactional-adapter-drizzle-orm.ts
+++ b/packages/transactional-adapters/transactional-adapter-drizzle-orm/src/lib/transactional-adapter-drizzle-orm.ts
@@ -1,4 +1,5 @@
 import { TransactionalAdapter } from '@nestjs-cls/transactional';
+import { EntityManager } from 'typeorm';
 
 type AnyDrizzleClient = {
     transaction: (
@@ -50,6 +51,17 @@ export class TransactionalAdapterDrizzleOrm<TClient extends AnyDrizzleClient>
             setClient: (client?: TClient) => void,
         ) => {
             return drizzleInstance.transaction(async (tx) => {
+                setClient(tx as TClient);
+                return fn();
+            }, options);
+        },
+        wrapWithNestedTransaction: async (
+            options: DrizzleTransactionOptions<TClient>,
+            fn: (...args: any[]) => Promise<any>,
+            setClient: (client?: TClient) => void,
+            client: TClient,
+        ) => {
+            return client.transaction(async (tx) => {
                 setClient(tx as TClient);
                 return fn();
             }, options);

--- a/packages/transactional-adapters/transactional-adapter-knex/src/lib/transactional-adapter-knex.ts
+++ b/packages/transactional-adapters/transactional-adapter-knex/src/lib/transactional-adapter-knex.ts
@@ -37,6 +37,17 @@ export class TransactionalAdapterKnex
                 return fn();
             }, options);
         },
+        wrapWithNestedTransaction: (
+            options: Knex.TransactionConfig,
+            fn: (...args: any[]) => Promise<any>,
+            setClient: (client?: Knex) => void,
+            client: Knex
+        ) => {
+          return client.transaction(async (trx) => {
+              setClient(trx);
+              return fn();
+          },options)
+        },
         getFallbackInstance: () => knexInstance,
     });
 }

--- a/packages/transactional-adapters/transactional-adapter-kysely/src/lib/transactional-adapter-kysely.ts
+++ b/packages/transactional-adapters/transactional-adapter-kysely/src/lib/transactional-adapter-kysely.ts
@@ -1,5 +1,6 @@
 import { TransactionalAdapter } from '@nestjs-cls/transactional';
 import { Kysely, TransactionBuilder } from 'kysely';
+import { EntityManager } from 'typeorm';
 
 export interface KyselyTransactionalAdapterOptions {
     /**
@@ -54,6 +55,9 @@ export class TransactionalAdapterKysely<DB = any>
                 return fn();
             });
         },
+        // kysely orm does not support nested transaction. but support manual save point.
+        // https://kysely.dev/docs/examples/transactions/controlled-transaction-w-savepoints
+
         getFallbackInstance: () => kyselyDb,
     });
 }

--- a/packages/transactional-adapters/transactional-adapter-pg-promise/src/lib/transactional-adapter-pg-promise.ts
+++ b/packages/transactional-adapters/transactional-adapter-pg-promise/src/lib/transactional-adapter-pg-promise.ts
@@ -41,6 +41,17 @@ export class TransactionalAdapterPgPromise
                 return fn();
             });
         },
+        wrapWithNestedTransaction: async (
+            options: PgPromiseTxOptions,
+            fn: (...args: any[]) => Promise<any>,
+            setClient: (client?: Database) => void,
+            client: Database,
+        ) => {
+            return client.tx(options, (tx) => {
+                setClient(tx as unknown as Database);
+                return fn();
+            });
+        },
         getFallbackInstance: () => pgPromiseDbInstance,
     });
 }


### PR DESCRIPTION
I add save point feature to adapters.

There seems to only` drizzle-orm, knex, pg-promise and typeorm` support save point at this time. and kysely only support manual save point.

so currently we can only support these 4 adapters