### PR TITLE
fix(core): improve ClsPluginsHooksHost error message and document app.init() requirement

### DIFF
--- a/docs/docs/07_testing/index.md
+++ b/docs/docs/07_testing/index.md
@@ -91,3 +91,24 @@ describe('CatService', () => {
   })
 })
 ```
+
+## Testing with plugins or `@UseCls()`
+
+When your test uses CLS [plugins](../06_plugins/index.md) or the [`@UseCls()` decorator](../02_setting-up-cls-context/04_using-a-decorator.md), you must call `await module.init()` after compiling the test module. Without it, the plugin hooks host is not initialized and throws a `ClsPluginsHooksHost not initialized` error.
+
+```ts
+beforeEach(async () => {
+    const module = await Test.createTestingModule({
+        imports: [
+            ClsModule.forRoot({ plugins: [myPlugin] }),
+        ],
+    }).compile();
+
+    // highlight-start
+    // Required when using CLS plugins or @UseCls() — initializes plugin hooks.
+    await module.init();
+    // highlight-end
+
+    service = module.get(MyService);
+});
+```

--- a/docs/docs/10_migration-guide/01_v5x-v6x.md
+++ b/docs/docs/10_migration-guide/01_v5x-v6x.md
@@ -47,3 +47,16 @@ const instance = this.cls.proxy.get(SomeProxyProvider);
 Both of these changes _do affect_ the `@nestjs-cls/transactional` plugin. Make sure to update it to version `v3.x` or higher.
 
 Transactional adapter packages are not affected, but it is still recommended to keep them on the latest version.
+
+## `await module.init()` required when using plugins or `@UseCls()` in tests
+
+Since v6, CLS plugins and the `@UseCls()` decorator rely on infrastructure initialized during `onApplicationBootstrap`. In tests that use `Test.createTestingModule`, this hook is not called unless you explicitly call `await module.init()`.
+
+If you upgrade from v4/v5 and your tests throw `ClsPluginsHooksHost not initialized`, add `await module.init()` to your setup:
+
+```ts
+const module = await Test.createTestingModule({ ... }).compile();
+// highlight-start
+await module.init(); // required in v6 when using plugins or @UseCls()
+// highlight-end
+```

--- a/packages/core/src/lib/plugin/cls-plugin-hooks-host.ts
+++ b/packages/core/src/lib/plugin/cls-plugin-hooks-host.ts
@@ -19,7 +19,9 @@ export class ClsPluginsHooksHost implements OnModuleInit {
     private static _instance: ClsPluginsHooksHost;
     static getInstance(): ClsPluginsHooksHost {
         if (!this._instance) {
-            throw new Error('ClsPluginsHooksHost not initialized');
+            throw new Error(
+                "ClsPluginsHooksHost not initialized. Make sure to call `await app.init()` before using CLS plugins (e.g. in your test's `beforeAll`/`beforeEach`).",
+            );
         }
         return this._instance;
     }


### PR DESCRIPTION
Fixes #374

Adds a hint to call `await app.init()` before using CLS plugins in tests. Adds a testing documentation section covering this requirement.