### PR TITLE
feat(transactional-adapter-drizzle-orm): accept drizzle-orm v1 in the peer range

### DIFF
--- a/packages/transactional-adapters/transactional-adapter-drizzle-orm/package.json
+++ b/packages/transactional-adapters/transactional-adapter-drizzle-orm/package.json
@@ -48,7 +48,7 @@
     },
     "peerDependencies": {
         "@nestjs-cls/transactional": "workspace:^3.2.0",
-        "drizzle-orm": "^0",
+        "drizzle-orm": "^0 || >=1.0.0-rc.1 <2.0.0",
         "nestjs-cls": "workspace:^6.2.0"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7102,7 +7102,7 @@ __metadata:
     typescript: "npm:5.9.3"
   peerDependencies:
     "@nestjs-cls/transactional": "workspace:^3.2.0"
-    drizzle-orm: ^0
+    drizzle-orm: ^0 || >=1.0.0-rc.1 <2.0.0
     nestjs-cls: "workspace:^6.2.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Closes #599.

drizzle-orm v1 is at `1.0.0-rc.4` and the `^0` peer pin fails resolution for anyone installing the adapter next to it. The adapter itself is unaffected by v1's API changes — `src` has no `drizzle-orm` import at all; the client is an opaque value — so the pin is the only blocker.

**Change (2 lines):** peer range → `"^0 || >=1.0.0-rc.1 <2.0.0"` + the matching `yarn.lock` entry. The explicit prerelease comparator is required because plain semver ranges never match prereleases (`<2.0.0` alone does not admit `1.0.0-rc.4`); the range also covers stable `1.x`, so GA needs no further change.

**Runtime evidence:** [nest-native/drizzle's CI](https://github.com/nest-native/drizzle/actions) runs a real commit/rollback through `TransactionalAdapterDrizzleOrm` (via `ClsPluginTransactional` + `@Transactional()`, libSQL driver) against `drizzle-orm@rc` on every push — green on `1.0.0-rc.4` ([spec](https://github.com/nest-native/drizzle/blob/main/packages/drizzle/test/drizzle-integration.spec.ts), [canary job](https://github.com/nest-native/drizzle/blob/main/.github/workflows/ci.yml)).

This package's own jest specs stay on the stable `0.45.x` devDependency, so CI here is unaffected. (They use RQB v1's `{ schema }` config, which v1 replaces with the relations API — worth migrating only if you want a dedicated v1 test lane; happy to follow up with that separately if useful.)